### PR TITLE
set base url to messiah-meal-planner

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react-swc'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/messiah-meal-planner'
 })


### PR DESCRIPTION
Set the base URL to "/messiah-meal-planner" so the gh-page directs the user to the correct directory.