### PR TITLE
Custom meal editor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,8 @@ import {
   EndDateCtx,
   UserSelectedMealsCtx,
   IsBreakCtx,
-  MealQueueCtx
+  MealQueueCtx,
+  CustomMealsCtx
 } from './static/context';
 import { useState } from 'react';
 import Meal from './types/Meal';
@@ -33,6 +34,10 @@ function App() {
     'mealQueue',
     []
   );
+  const [customMeals, setCustomMeals] = usePersistentState<Array<Meal>>(
+    'customMeals',
+    []
+  );
   const [areDetailsEntered, setAreDetailsEntered] = useState(false);
 
   return (
@@ -54,29 +59,33 @@ function App() {
                 <MealQueueCtx.Provider
                   value={{ value: mealQueue, setValue: setMealQueue }}
                 >
-                  <ScreenContainer>
-                    <header className='bg-messiah-blue rounded-xl border-4 border-white shadow-md w-full mb-4'>
-                      <h1 className='font-semibold text-4xl text-white text-center p-8'>
-                        Messiah Meal Planner
-                      </h1>
-                    </header>
-                    <MealPlanInfo onEnterDetails={setAreDetailsEntered} />
-                    {areDetailsEntered ? (
-                      <>
-                        <AvailableMeals />
-                        <MealQueue />
-                        <DayEditor />
-                        <Results />
-                        <ResultsBar />
-                      </>
-                    ) : (
-                      <div className='flex flex-col items-center'>
-                        <p className='text-gray-400'>
-                          Enter meal plan info to continue planning.
-                        </p>
-                      </div>
-                    )}
-                  </ScreenContainer>
+                  <CustomMealsCtx.Provider
+                    value={{ value: customMeals, setValue: setCustomMeals }}
+                  >
+                    <ScreenContainer>
+                      <header className='bg-messiah-blue rounded-xl border-4 border-white shadow-md w-full mb-4'>
+                        <h1 className='font-semibold text-4xl text-white text-center p-8'>
+                          Messiah Meal Planner
+                        </h1>
+                      </header>
+                      <MealPlanInfo onEnterDetails={setAreDetailsEntered} />
+                      {areDetailsEntered ? (
+                        <>
+                          <AvailableMeals />
+                          <MealQueue />
+                          <DayEditor />
+                          <Results />
+                          <ResultsBar />
+                        </>
+                      ) : (
+                        <div className='flex flex-col items-center'>
+                          <p className='text-gray-400'>
+                            Enter meal plan info to continue planning.
+                          </p>
+                        </div>
+                      )}
+                    </ScreenContainer>
+                  </CustomMealsCtx.Provider>
                 </MealQueueCtx.Provider>
               </UserSelectedMealsCtx.Provider>
             </EndDateCtx.Provider>

--- a/src/components/containers/MealContainer.tsx
+++ b/src/components/containers/MealContainer.tsx
@@ -12,10 +12,10 @@ interface MealContainerProps {
   addOrRemove?: string;
   customMeal?: boolean;
   children?: React.ReactNode;
-  includeCustomEditor?: boolean;
   meals: Meal[];
   buttonOnClick: (meal: Meal) => unknown;
   createNotification: (name: string) => string;
+  onCustomClick?: (data: Meal) => void;
 }
 
 // Default column
@@ -30,7 +30,7 @@ const DEFAULT_DIRECTION = true;
  * @param {Meal[]} meals The list of meals to display
  * @param {(index: Meal) => unkown} buttonOnClick Handle the add or remove button click
  * @param {(string) => string} notificationMessage - A function that takes in the meal name and returns the notification message when the meal button is clicked.
- * @param {boolean} includeCustomEditor Whether or not to include the custom meal editor
+ * @param {() => void} onCustomClick - The click event handler for editing a custom meal
  * @return {JSX.Element} The Available Meals section component.
  */
 const MealContainer = ({
@@ -40,7 +40,7 @@ const MealContainer = ({
   meals,
   buttonOnClick,
   createNotification,
-  includeCustomEditor
+  onCustomClick
 }: MealContainerProps) => {
   // State variable to determine whether or not the sorting modal should be open
   const [isSorting, setIsSorting] = useState(false);
@@ -71,7 +71,7 @@ const MealContainer = ({
         sortDirection={sortDirection}
         buttonOnClick={buttonOnClick}
         createNotification={createNotification}
-        includeCustomEditor={includeCustomEditor}
+        onCustomClick={onCustomClick}
       />
       <SortingModal
         sortColumn={sortColumn}

--- a/src/components/containers/MealContainer.tsx
+++ b/src/components/containers/MealContainer.tsx
@@ -16,6 +16,7 @@ interface MealContainerProps {
   buttonOnClick: (meal: Meal) => unknown;
   createNotification: (name: string) => string;
   onCustomClick?: (data: Meal) => void;
+  newCustomMealID?: string;
 }
 
 // Default column
@@ -31,6 +32,7 @@ const DEFAULT_DIRECTION = true;
  * @param {(index: Meal) => unkown} buttonOnClick Handle the add or remove button click
  * @param {(string) => string} notificationMessage - A function that takes in the meal name and returns the notification message when the meal button is clicked.
  * @param {() => void} onCustomClick - The click event handler for editing a custom meal
+ * @param {string | undefined} newCustomMealID - The ID of the newly added custom meal to scroll to
  * @return {JSX.Element} The Available Meals section component.
  */
 const MealContainer = ({
@@ -40,7 +42,8 @@ const MealContainer = ({
   meals,
   buttonOnClick,
   createNotification,
-  onCustomClick
+  onCustomClick,
+  newCustomMealID
 }: MealContainerProps) => {
   // State variable to determine whether or not the sorting modal should be open
   const [isSorting, setIsSorting] = useState(false);
@@ -72,6 +75,7 @@ const MealContainer = ({
         buttonOnClick={buttonOnClick}
         createNotification={createNotification}
         onCustomClick={onCustomClick}
+        newCustomMealID={newCustomMealID}
       />
       <SortingModal
         sortColumn={sortColumn}

--- a/src/components/containers/MealContainer.tsx
+++ b/src/components/containers/MealContainer.tsx
@@ -12,6 +12,7 @@ interface MealContainerProps {
   addOrRemove?: string;
   customMeal?: boolean;
   children?: React.ReactNode;
+  includeCustomEditor?: boolean;
   meals: Meal[];
   buttonOnClick: (meal: Meal) => unknown;
   createNotification: (name: string) => string;
@@ -29,6 +30,7 @@ const DEFAULT_DIRECTION = true;
  * @param {Meal[]} meals The list of meals to display
  * @param {(index: Meal) => unkown} buttonOnClick Handle the add or remove button click
  * @param {(string) => string} notificationMessage - A function that takes in the meal name and returns the notification message when the meal button is clicked.
+ * @param {boolean} includeCustomEditor Whether or not to include the custom meal editor
  * @return {JSX.Element} The Available Meals section component.
  */
 const MealContainer = ({
@@ -38,6 +40,7 @@ const MealContainer = ({
   meals,
   buttonOnClick,
   createNotification,
+  includeCustomEditor
 }: MealContainerProps) => {
   // State variable to determine whether or not the sorting modal should be open
   const [isSorting, setIsSorting] = useState(false);
@@ -68,6 +71,7 @@ const MealContainer = ({
         sortDirection={sortDirection}
         buttonOnClick={buttonOnClick}
         createNotification={createNotification}
+        includeCustomEditor={includeCustomEditor}
       />
       <SortingModal
         sortColumn={sortColumn}

--- a/src/components/containers/table/MealTable.tsx
+++ b/src/components/containers/table/MealTable.tsx
@@ -16,6 +16,7 @@ interface MealTableProps {
   buttonOnClick: (meal: Meal) => void;
   createNotification: (name: string) => string;
   onCustomClick?: (data: Meal) => void;
+  newCustomMealID?: string;
 }
 
 /**
@@ -29,6 +30,7 @@ interface MealTableProps {
  * @param {(Meal) => void} buttonOnClick - The click event handler for the optional button
  * @param {(string) => string} notificationMessage - A function that takes in the meal name and returns the notification message when the meal button is clicked.
  * @param {() => void} onCustomClick - The click event handler for editing a custom meal
+ * @param {string | undefined} newCustomMealID - The ID of the newly added custom meal to scroll to
  * @return {JSX.Element} The rendered table component
  */
 const MealTable = ({
@@ -39,7 +41,8 @@ const MealTable = ({
   buttonOnClick,
   createNotification,
   sortDirection,
-  onCustomClick
+  onCustomClick,
+  newCustomMealID,
 }: MealTableProps): JSX.Element => {
   const headers = ['Location', 'Name', 'Price', buttonTitle ?? null];
   if (sortedBy === undefined) {
@@ -94,6 +97,7 @@ const MealTable = ({
                 buttonIcon={buttonIcon}
                 buttonOnClick={() => handleButtonClick(row)}
                 onCustomClick={onCustomClick}
+                newCustomMealID={newCustomMealID}
               />
             ))}
           </tbody>

--- a/src/components/containers/table/MealTable.tsx
+++ b/src/components/containers/table/MealTable.tsx
@@ -15,7 +15,7 @@ interface MealTableProps {
   sortDirection?: boolean;
   buttonOnClick: (meal: Meal) => void;
   createNotification: (name: string) => string;
-  includeCustomEditor?: boolean;
+  onCustomClick?: (data: Meal) => void;
 }
 
 /**
@@ -28,7 +28,7 @@ interface MealTableProps {
  * @param {boolean} sortDirection - The direction to sort the table in, true = ascending, false = descending
  * @param {(Meal) => void} buttonOnClick - The click event handler for the optional button
  * @param {(string) => string} notificationMessage - A function that takes in the meal name and returns the notification message when the meal button is clicked.
- * @param {boolean} includeCustomEditor - Whether or not to include the custom meal editor
+ * @param {() => void} onCustomClick - The click event handler for editing a custom meal
  * @return {JSX.Element} The rendered table component
  */
 const MealTable = ({
@@ -39,7 +39,7 @@ const MealTable = ({
   buttonOnClick,
   createNotification,
   sortDirection,
-  includeCustomEditor
+  onCustomClick
 }: MealTableProps): JSX.Element => {
   const headers = ['Location', 'Name', 'Price', buttonTitle ?? null];
   if (sortedBy === undefined) {
@@ -93,7 +93,7 @@ const MealTable = ({
                 data={row}
                 buttonIcon={buttonIcon}
                 buttonOnClick={() => handleButtonClick(row)}
-                includeCustomEditor={includeCustomEditor}
+                onCustomClick={onCustomClick}
               />
             ))}
           </tbody>

--- a/src/components/containers/table/MealTable.tsx
+++ b/src/components/containers/table/MealTable.tsx
@@ -14,7 +14,8 @@ interface MealTableProps {
   sortedBy?: string;
   sortDirection?: boolean;
   buttonOnClick: (meal: Meal) => void;
-  createNotification: ((name: string) => string);
+  createNotification: (name: string) => string;
+  includeCustomEditor?: boolean;
 }
 
 /**
@@ -27,6 +28,7 @@ interface MealTableProps {
  * @param {boolean} sortDirection - The direction to sort the table in, true = ascending, false = descending
  * @param {(Meal) => void} buttonOnClick - The click event handler for the optional button
  * @param {(string) => string} notificationMessage - A function that takes in the meal name and returns the notification message when the meal button is clicked.
+ * @param {boolean} includeCustomEditor - Whether or not to include the custom meal editor
  * @return {JSX.Element} The rendered table component
  */
 const MealTable = ({
@@ -37,6 +39,7 @@ const MealTable = ({
   buttonOnClick,
   createNotification,
   sortDirection,
+  includeCustomEditor
 }: MealTableProps): JSX.Element => {
   const headers = ['Location', 'Name', 'Price', buttonTitle ?? null];
   if (sortedBy === undefined) {
@@ -44,12 +47,12 @@ const MealTable = ({
   }
 
   // The notification message
-  const [message, setMessage] = useState({text: ''});
+  const [message, setMessage] = useState({ text: '' });
 
   const handleButtonClick = (row: Meal) => {
     buttonOnClick(row);
-    setMessage({text: createNotification(row.name)});
-  }
+    setMessage({ text: createNotification(row.name) });
+  };
 
   // Sort data
   const sortedData = useMemo(
@@ -59,40 +62,47 @@ const MealTable = ({
 
   return (
     <>
-    <div className={`overflow-y-scroll flex-grow max-h-[400px] w-full ${data.length > 0 ? '' : 'hidden'}`}>
-      <table className='w-full [&_tr>td:nth-child(-n+2)]:text-left [&_tr>td:nth-child(n+3)]:text-right'>
-        {/* Table header */}
-        <thead>
-          <tr>
-            {headers.map((header, index) =>
-              header !== null ? (
-                <TableCell
-                  key={index}
-                  data={header}
-                  importance={newImportanceIndex(header === sortedBy ? 5 : 4)}
-                  isHeader={true}
-                />
-              ) : (
-                <Fragment key={index}></Fragment>
-              )
-            )}
-          </tr>
-        </thead>
-        {/* Table body */}
-        <tbody>
-          {sortedData.map((row, index) => (
-            <TableRow
-              key={index}
-              data={row}
-              buttonIcon={buttonIcon}
-              buttonOnClick={() => handleButtonClick(row)}
-            />
-          ))}
-        </tbody>
-      </table>
-    </div>
-    <p className={`p-6 text-gray-400 ${data.length > 0 ? 'hidden' : ''}`}>No meals to display.</p>
-    <Notification message={message}/>
+      <div
+        className={`overflow-y-scroll flex-grow max-h-[400px] w-full ${
+          data.length > 0 ? '' : 'hidden'
+        }`}
+      >
+        <table className='w-full [&_tr>td:nth-child(-n+2)]:text-left [&_tr>td:nth-child(n+3)]:text-right'>
+          {/* Table header */}
+          <thead>
+            <tr>
+              {headers.map((header, index) =>
+                header !== null ? (
+                  <TableCell
+                    key={index}
+                    data={header}
+                    importance={newImportanceIndex(header === sortedBy ? 5 : 4)}
+                    isHeader={true}
+                  />
+                ) : (
+                  <Fragment key={index}></Fragment>
+                )
+              )}
+            </tr>
+          </thead>
+          {/* Table body */}
+          <tbody>
+            {sortedData.map((row, index) => (
+              <TableRow
+                key={index}
+                data={row}
+                buttonIcon={buttonIcon}
+                buttonOnClick={() => handleButtonClick(row)}
+                includeCustomEditor={includeCustomEditor}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className={`p-6 text-gray-400 ${data.length > 0 ? 'hidden' : ''}`}>
+        No meals to display.
+      </p>
+      <Notification message={message} />
     </>
   );
 };

--- a/src/components/containers/table/TableCell.tsx
+++ b/src/components/containers/table/TableCell.tsx
@@ -27,7 +27,7 @@ const TableCell = ({
   importance = newImportanceIndex(3),
   isHeader = false,
   isCustom = false,
-  onCustomClick = () => {}
+  onCustomClick
 }: TableCellProps): JSX.Element => {
   const importanceStyle = IMPORTANCE_CLASSES[importance] ?? 'font-normal';
 
@@ -37,7 +37,7 @@ const TableCell = ({
         isHeader ? 'border-b-4 border-b-messiah-blue' : ''
       } p-2 text-center`}
     >
-      {isCustom ? (
+      {isCustom && onCustomClick !== undefined ? (
         <button
           className='bg-transparent border-none font-inter underline text-messiah-blue hover:text-messiah-blue-hover p-0 m-0'
           type='button'

--- a/src/components/containers/table/TableCell.tsx
+++ b/src/components/containers/table/TableCell.tsx
@@ -8,6 +8,8 @@ interface TableCellProps {
   data: string | number;
   importance?: ImportanceIndex;
   isHeader?: boolean;
+  isCustom?: boolean;
+  onCustomClick?: () => void;
 }
 
 /**
@@ -15,12 +17,17 @@ interface TableCellProps {
  *
  * @param {string | number} data - The data to be displayed in the table cell
  * @param {ImportanceIndex} importance - The importance level of the table cell
+ * @param {boolean} isHeader - Whether the table cell is a header
+ * @param {boolean} isCustom - Whether the table cell represents a custom meal
+ * @param {() => void} onCustomClick - The click event handler for clicking on a custom meal
  * @returns {JSX.Element} The rendered table cell
  */
 const TableCell = ({
   data,
   importance = newImportanceIndex(3),
-  isHeader = false
+  isHeader = false,
+  isCustom = false,
+  onCustomClick = () => {}
 }: TableCellProps): JSX.Element => {
   const importanceStyle = IMPORTANCE_CLASSES[importance] ?? 'font-normal';
 
@@ -30,7 +37,17 @@ const TableCell = ({
         isHeader ? 'border-b-4 border-b-messiah-blue' : ''
       } p-2 text-center`}
     >
-      {data}
+      {isCustom ? (
+        <button
+          className='bg-transparent border-none font-inter underline text-messiah-blue hover:text-messiah-blue-hover p-0 m-0'
+          type='button'
+          onClick={onCustomClick}
+        >
+          {data}
+        </button>
+      ) : (
+        data
+      )}
     </td>
   );
 };

--- a/src/components/containers/table/TableRow.tsx
+++ b/src/components/containers/table/TableRow.tsx
@@ -3,12 +3,14 @@ import Meal from '../../../types/Meal';
 import ButtonCell from './ButtonCell';
 import TableCell from './TableCell';
 import formatCurrency from '../../../lib/formatCurrency';
+import { useEffect, useRef } from 'react';
 
 interface TableRowProps {
   data: Meal;
   buttonIcon?: JSX.Element;
   buttonOnClick?: () => void;
   onCustomClick?: (data: Meal) => void;
+  newCustomMealID?: string;
 }
 
 /**
@@ -18,13 +20,15 @@ interface TableRowProps {
  * @param {JSX.Element} buttonIcon - The icon for the button
  * @param {() => void} buttonOnClick - The click event handler for the button
  * @param {() => void} onCustomClick - The click event handler for editing a custom meal
+ * @param {string} newCustomMealID - The ID of the newly added custom meal to be scrolled to
  * @return {JSX.Element} The rendered table row.
  */
 const TableRow = ({
   data,
   buttonIcon,
   buttonOnClick,
-  onCustomClick
+  onCustomClick,
+  newCustomMealID,
 }: TableRowProps): JSX.Element => {
   /**
    * Updates a custom meal in the customMeals context with the provided location, name, and price.
@@ -35,10 +39,21 @@ const TableRow = ({
    * @return {void} This function does not return anything.
    */
 
+  const tr = useRef<HTMLTableRowElement>(null);
+
+  useEffect(() => {
+    if (newCustomMealID && data.id === newCustomMealID && tr.current)
+      tr.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center'
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [newCustomMealID]);
+
   return (
     <>
       {/* Table row */}
-      <tr>
+      <tr ref={tr}>
         <TableCell data={data.location} importance={newImportanceIndex(1)} />
         <TableCell
           data={data.name}

--- a/src/components/containers/table/TableRow.tsx
+++ b/src/components/containers/table/TableRow.tsx
@@ -44,8 +44,8 @@ const TableRow = ({
           data={data.name}
           isCustom={data.isCustom}
           importance={newImportanceIndex(2)}
-          onCustomClick={() =>
-            onCustomClick !== undefined ? onCustomClick(data) : null
+          onCustomClick={
+            onCustomClick !== undefined ? () => onCustomClick(data) : undefined
           }
         />
         <TableCell

--- a/src/components/containers/table/TableRow.tsx
+++ b/src/components/containers/table/TableRow.tsx
@@ -3,11 +3,15 @@ import Meal from '../../../types/Meal';
 import ButtonCell from './ButtonCell';
 import TableCell from './TableCell';
 import formatCurrency from '../../../lib/formatCurrency';
+import { useState, useContext } from 'react';
+import CustomMealAddModal from '../../modals/CustomMealAddModal';
+import { CustomMealsCtx } from '../../../static/context';
 
 interface TableRowProps {
   data: Meal;
   buttonIcon?: JSX.Element;
   buttonOnClick?: () => void;
+  includeCustomEditor?: boolean;
 }
 
 /**
@@ -16,26 +20,79 @@ interface TableRowProps {
  * @param {Meal} data - The data for the table row
  * @param {JSX.Element} buttonIcon - The icon for the button
  * @param {() => void} buttonOnClick - The click event handler for the button
+ * @param {boolean} includeCustomEditor - Whether or not to include the custom meal editor
  * @return {JSX.Element} The rendered table row.
  */
 const TableRow = ({
   data,
   buttonIcon,
-  buttonOnClick
-}: TableRowProps): JSX.Element => (
-  <tr>
-    <TableCell data={data.location} importance={newImportanceIndex(1)} />
-    <TableCell data={data.name} importance={newImportanceIndex(2)} />
-    <TableCell
-      data={formatCurrency(data.price)}
-      importance={newImportanceIndex(2)}
-    />
-    {buttonIcon && buttonOnClick ? (
-      <ButtonCell icon={buttonIcon} onClick={buttonOnClick} />
-    ) : (
-      <></>
-    )}
-  </tr>
-);
+  buttonOnClick,
+  includeCustomEditor
+}: TableRowProps): JSX.Element => {
+  // State variable to determine whether or not the custom meal modal should be open
+  const [isEditingCustomMeal, setIsEditingCustomMeal] = useState(false);
+
+  // Load custom meals context
+  const customMeals = useContext(CustomMealsCtx);
+
+  /**
+   * Updates a custom meal in the customMeals context with the provided location, name, and price.
+   *
+   * @param {string} location - The new location for the custom meal.
+   * @param {string} name - The new name for the custom meal.
+   * @param {number} price - The new price for the custom meal.
+   * @return {void} This function does not return anything.
+   */
+  const onUpdateCustomMeal = (
+    location: string,
+    name: string,
+    price: number
+  ) => {
+    customMeals.setValue(
+      customMeals.value.map((val) =>
+        val.id === data.id ? { ...val, location, name, price } : val
+      )
+    );
+    setIsEditingCustomMeal(false);
+  };
+
+  return (
+    <>
+      <CustomMealAddModal
+        startingData={data}
+        onConfirm={onUpdateCustomMeal}
+        onCancel={() => {
+          setIsEditingCustomMeal(false);
+        }}
+        onDelete={() => {
+          customMeals.setValue(
+            customMeals.value.filter((val) => val.id !== data.id)
+          );
+          setIsEditingCustomMeal(false);
+        }}
+        visible={isEditingCustomMeal}
+      />
+      {/* Table row */}
+      <tr>
+        <TableCell data={data.location} importance={newImportanceIndex(1)} />
+        <TableCell
+          data={data.name}
+          isCustom={data.isCustom && includeCustomEditor}
+          importance={newImportanceIndex(2)}
+          onCustomClick={() => setIsEditingCustomMeal(true)}
+        />
+        <TableCell
+          data={formatCurrency(data.price)}
+          importance={newImportanceIndex(2)}
+        />
+        {buttonIcon && buttonOnClick ? (
+          <ButtonCell icon={buttonIcon} onClick={buttonOnClick} />
+        ) : (
+          <></>
+        )}
+      </tr>
+    </>
+  );
+};
 
 export default TableRow;

--- a/src/components/containers/table/TableRow.tsx
+++ b/src/components/containers/table/TableRow.tsx
@@ -3,15 +3,12 @@ import Meal from '../../../types/Meal';
 import ButtonCell from './ButtonCell';
 import TableCell from './TableCell';
 import formatCurrency from '../../../lib/formatCurrency';
-import { useState, useContext } from 'react';
-import CustomMealAddModal from '../../modals/CustomMealAddModal';
-import { CustomMealsCtx } from '../../../static/context';
 
 interface TableRowProps {
   data: Meal;
   buttonIcon?: JSX.Element;
   buttonOnClick?: () => void;
-  includeCustomEditor?: boolean;
+  onCustomClick?: (data: Meal) => void;
 }
 
 /**
@@ -20,21 +17,15 @@ interface TableRowProps {
  * @param {Meal} data - The data for the table row
  * @param {JSX.Element} buttonIcon - The icon for the button
  * @param {() => void} buttonOnClick - The click event handler for the button
- * @param {boolean} includeCustomEditor - Whether or not to include the custom meal editor
+ * @param {() => void} onCustomClick - The click event handler for editing a custom meal
  * @return {JSX.Element} The rendered table row.
  */
 const TableRow = ({
   data,
   buttonIcon,
   buttonOnClick,
-  includeCustomEditor
+  onCustomClick
 }: TableRowProps): JSX.Element => {
-  // State variable to determine whether or not the custom meal modal should be open
-  const [isEditingCustomMeal, setIsEditingCustomMeal] = useState(false);
-
-  // Load custom meals context
-  const customMeals = useContext(CustomMealsCtx);
-
   /**
    * Updates a custom meal in the customMeals context with the provided location, name, and price.
    *
@@ -43,43 +34,19 @@ const TableRow = ({
    * @param {number} price - The new price for the custom meal.
    * @return {void} This function does not return anything.
    */
-  const onUpdateCustomMeal = (
-    location: string,
-    name: string,
-    price: number
-  ) => {
-    customMeals.setValue(
-      customMeals.value.map((val) =>
-        val.id === data.id ? { ...val, location, name, price } : val
-      )
-    );
-    setIsEditingCustomMeal(false);
-  };
 
   return (
     <>
-      <CustomMealAddModal
-        startingData={data}
-        onConfirm={onUpdateCustomMeal}
-        onCancel={() => {
-          setIsEditingCustomMeal(false);
-        }}
-        onDelete={() => {
-          customMeals.setValue(
-            customMeals.value.filter((val) => val.id !== data.id)
-          );
-          setIsEditingCustomMeal(false);
-        }}
-        visible={isEditingCustomMeal}
-      />
       {/* Table row */}
       <tr>
         <TableCell data={data.location} importance={newImportanceIndex(1)} />
         <TableCell
           data={data.name}
-          isCustom={data.isCustom && includeCustomEditor}
+          isCustom={data.isCustom}
           importance={newImportanceIndex(2)}
-          onCustomClick={() => setIsEditingCustomMeal(true)}
+          onCustomClick={() =>
+            onCustomClick !== undefined ? onCustomClick(data) : null
+          }
         />
         <TableCell
           data={formatCurrency(data.price)}

--- a/src/components/modals/CustomMealAddModal.tsx
+++ b/src/components/modals/CustomMealAddModal.tsx
@@ -4,11 +4,16 @@ import { Dispatch, SetStateAction, useMemo } from 'react';
 import { useState } from 'react';
 import ModalContainer from '../containers/ModalContainer';
 import { DINING_LOCATIONS } from '../../static/constants';
+import Meal from '../../types/Meal';
+import Button from '../form_elements/Button';
+import { FaTrash } from 'react-icons/fa';
 
 interface CustomMealAddModalProps {
   visible: boolean;
   onConfirm: (location: string, name: string, price: number) => void;
   onCancel: () => void;
+  onDelete?: () => void;
+  startingData?: Meal;
 }
 
 /**
@@ -17,12 +22,16 @@ interface CustomMealAddModalProps {
  * @param {boolean} visible - Whether or not the modal is visible.
  * @param {(location: string, name: string, price: number) => void} onConfirm - Event handler for when the confirm button is clicked.
  * @param {() => void} onCancel - Event handler for when the cancel button is clicked.
+ * @param {() => void} onDelete - Event handler for when the delete button is clicked.
+ * @param {Meal | undefined} startingData - The starting data for the modal.
  * @returns {JSX.Element} The rendered CustomMealAddModal component.
  */
 const CustomMealAddModal = ({
   visible,
   onConfirm,
-  onCancel
+  onCancel,
+  onDelete,
+  startingData
 }: CustomMealAddModalProps) => {
   // Default values
   const DEFAULT_LOCATION = 'Select Location...';
@@ -30,9 +39,11 @@ const CustomMealAddModal = ({
   const DEFAULT_NAME = '';
 
   // State variables for use in adding a custom meal
-  const [location, setLocation] = useState(DEFAULT_LOCATION);
-  const [price, setPrice] = useState(DEFAULT_PRICE);
-  const [name, setName] = useState(DEFAULT_NAME);
+  const [location, setLocation] = useState(
+    startingData?.location ?? DEFAULT_LOCATION
+  );
+  const [price, setPrice] = useState(startingData?.price ?? DEFAULT_PRICE);
+  const [name, setName] = useState(startingData?.name ?? DEFAULT_NAME);
 
   // Reset modal state
   const resetState = () => {
@@ -53,8 +64,8 @@ const CustomMealAddModal = ({
 
   return visible ? (
     <ModalContainer
-      title='Add Custom Meal'
-      confirmText='Add'
+      title={`${startingData ? 'Edit' : 'Add'} Custom Meal`}
+      confirmText={startingData ? 'Update' : 'Add'}
       onConfirm={() => {
         onConfirm(location, name, price);
         resetState();
@@ -91,6 +102,14 @@ const CustomMealAddModal = ({
             (!isNaN(parseFloat(str)) && parseFloat(str) >= 0) || str === ''
           }
         />
+        {startingData && (
+          <Button
+            onClick={onDelete ?? (() => {})}
+            style='bg-messiah-red border-messiah-red hover:bg-messiah-red-hover hover:border-messiah-red-hover active:bg-messiah-red-active active:border-messiah-red-active text-white'
+            icon={<FaTrash />}
+            title='Delete Meal'
+          ></Button>
+        )}
       </form>
     </ModalContainer>
   ) : (

--- a/src/components/other/CustomMeal.tsx
+++ b/src/components/other/CustomMeal.tsx
@@ -1,33 +1,40 @@
-import { useState } from "react";
-import { GiMeal } from "react-icons/gi";
-import Button from "../form_elements/Button";
-import CustomMealAddModal from "../modals/CustomMealAddModal";
+import { useState, useContext } from 'react';
+import { GiMeal } from 'react-icons/gi';
+import Button from '../form_elements/Button';
+import CustomMealAddModal from '../modals/CustomMealAddModal';
+import { CustomMealsCtx } from '../../static/context';
+import { v4 as uuid } from 'uuid';
 
 /**
  * Renders a Custom Meal button and Modal.
  */
 const CustomMeal = () => {
+  // State variable to determine whether or not the custom meal modal should be open
+  const [isAddingCustomMeal, setIsAddingCustomMeal] = useState(false);
 
-    // State variable to determine whether or not the custom meal modal should be open
-    const [isAddingCustomMeal, setIsAddingCustomMeal] = useState(false);
-    
-    return (
-        <>
-            <Button
-                title='Custom Meal'
-                icon={<GiMeal />}
-                onClick={() => setIsAddingCustomMeal(true)} />
-                <CustomMealAddModal
-                    onConfirm={(location, name, price) => {
-                        console.log(location);
-                        console.log(name);
-                        console.log(price);
-                        setIsAddingCustomMeal(false);
-                    } }
-                    onCancel={() => setIsAddingCustomMeal(false)}
-                    visible={isAddingCustomMeal} />
-            </>
-    );
+  // Load custom meals context
+  const customMeals = useContext(CustomMealsCtx);
+
+  return (
+    <>
+      <Button
+        title='Custom Meal'
+        icon={<GiMeal />}
+        onClick={() => setIsAddingCustomMeal(true)}
+      />
+      <CustomMealAddModal
+        onConfirm={(location, name, price) => {
+          customMeals.setValue([
+            ...customMeals.value,
+            { location, name, price, isCustom: true, id: uuid() }
+          ]);
+          setIsAddingCustomMeal(false);
+        }}
+        onCancel={() => setIsAddingCustomMeal(false)}
+        visible={isAddingCustomMeal}
+      />
+    </>
+  );
 };
 
 export default CustomMeal;

--- a/src/components/other/CustomMeal.tsx
+++ b/src/components/other/CustomMeal.tsx
@@ -1,14 +1,22 @@
-import { useState, useContext } from 'react';
+import React, { useState, useContext } from 'react';
 import { GiMeal } from 'react-icons/gi';
 import Button from '../form_elements/Button';
 import CustomMealAddModal from '../modals/CustomMealAddModal';
 import { CustomMealsCtx } from '../../static/context';
 import { v4 as uuid } from 'uuid';
+import Meal from '../../types/Meal';
+
+interface CustomMealProps {
+  setNewCustomMealID: React.Dispatch<React.SetStateAction<string | undefined>>;
+}
 
 /**
  * Renders a Custom Meal button and Modal.
+ * @param {React.SetStateAction<Meal | undefined>} setNewCustomMeal Setter for newly added custom meals
  */
-const CustomMeal = () => {
+const CustomMeal = ({
+  setNewCustomMealID
+}: CustomMealProps) => {
   // State variable to determine whether or not the custom meal modal should be open
   const [isAddingCustomMeal, setIsAddingCustomMeal] = useState(false);
 
@@ -24,11 +32,13 @@ const CustomMeal = () => {
       />
       <CustomMealAddModal
         onConfirm={(location, name, price) => {
+          const newCustomMeal = { location, name, price, isCustom: true, id: uuid() };
           customMeals.setValue([
             ...customMeals.value,
-            { location, name, price, isCustom: true, id: uuid() }
+            newCustomMeal
           ]);
           setIsAddingCustomMeal(false);
+          setNewCustomMealID(newCustomMeal.id);
         }}
         onCancel={() => setIsAddingCustomMeal(false)}
         visible={isAddingCustomMeal}

--- a/src/components/other/CustomMeal.tsx
+++ b/src/components/other/CustomMeal.tsx
@@ -4,7 +4,6 @@ import Button from '../form_elements/Button';
 import CustomMealAddModal from '../modals/CustomMealAddModal';
 import { CustomMealsCtx } from '../../static/context';
 import { v4 as uuid } from 'uuid';
-import Meal from '../../types/Meal';
 
 interface CustomMealProps {
   setNewCustomMealID: React.Dispatch<React.SetStateAction<string | undefined>>;

--- a/src/components/sections/AvailableMeals.tsx
+++ b/src/components/sections/AvailableMeals.tsx
@@ -23,6 +23,8 @@ const AvailableMeals = () => {
   // State variable to track the current custom meal editing data
   const [currentCustomData, setCurrentCustomData] = useState<Meal>();
 
+  const [newCustomMealID, setNewCustomMealID] = useState<string>();
+
   /**
    * Updates a custom meal in the customMeals context with the provided location, name, and price.
    *
@@ -73,6 +75,7 @@ const AvailableMeals = () => {
         if (currentCustomData === data) setIsEditingCustomMeal(true);
         else setCurrentCustomData(data);
       }}
+      newCustomMealID={newCustomMealID}
     >
       {
         // This cannot work with only the 'visible' property because otherwise it will not re-render
@@ -98,7 +101,7 @@ const AvailableMeals = () => {
           <></>
         )
       }
-      <CustomMeal />
+      <CustomMeal setNewCustomMealID={setNewCustomMealID}/>
     </MealContainer>
   );
 };

--- a/src/components/sections/AvailableMeals.tsx
+++ b/src/components/sections/AvailableMeals.tsx
@@ -2,7 +2,7 @@ import meals from '../../static/mealsDatabase';
 import Meal from '../../types/Meal';
 import MealContainer from '../containers/MealContainer';
 import CustomMeal from '../other/CustomMeal';
-import { MealQueueCtx } from '../../static/context';
+import { CustomMealsCtx, MealQueueCtx } from '../../static/context';
 import { useContext } from 'react';
 import { v4 as uuid } from 'uuid';
 /**
@@ -12,8 +12,9 @@ import { v4 as uuid } from 'uuid';
  * @return {JSX.Element} The Available Meals section component.
  */
 const AvailableMeals = () => {
-  // Load meal queue context
+  // Load all necessary contexts
   const mealQueue = useContext(MealQueueCtx);
+  const customMeals = useContext(CustomMealsCtx);
 
   /**
    * Adds a meal to the queue.
@@ -28,9 +29,11 @@ const AvailableMeals = () => {
     <MealContainer
       title='Available Meals'
       addOrRemove='Add'
-      meals={meals}
+      meals={[...meals, ...customMeals.value]}
       buttonOnClick={addToQueue}
-      createNotification={(name) => `Added ${name} to meal queue`}>
+      createNotification={(name) => `Added ${name} to meal queue`}
+      includeCustomEditor={true}
+    >
       <CustomMeal />
     </MealContainer>
   );

--- a/src/components/sections/AvailableMeals.tsx
+++ b/src/components/sections/AvailableMeals.tsx
@@ -3,8 +3,9 @@ import Meal from '../../types/Meal';
 import MealContainer from '../containers/MealContainer';
 import CustomMeal from '../other/CustomMeal';
 import { CustomMealsCtx, MealQueueCtx } from '../../static/context';
-import { useContext } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { v4 as uuid } from 'uuid';
+import CustomMealAddModal from '../modals/CustomMealAddModal';
 /**
  * Renders the Available Meals section with a table of meals to add and a button
  * to add a custom meal. Displays the add custommeal modal when the button is clicked.
@@ -15,6 +16,40 @@ const AvailableMeals = () => {
   // Load all necessary contexts
   const mealQueue = useContext(MealQueueCtx);
   const customMeals = useContext(CustomMealsCtx);
+
+  // State variable to determine whether or not the custom meal modal should be open
+  const [isEditingCustomMeal, setIsEditingCustomMeal] = useState(false);
+
+  // State variable to track the current custom meal editing data
+  const [currentCustomData, setCurrentCustomData] = useState<Meal>();
+
+  /**
+   * Updates a custom meal in the customMeals context with the provided location, name, and price.
+   *
+   * @param {string} location - The new location for the custom meal.
+   * @param {string} name - The new name for the custom meal.
+   * @param {number} price - The new price for the custom meal.
+   * @return {void} This function does not return anything.
+   */
+  const onUpdateCustomMeal = (
+    location: string,
+    name: string,
+    price: number
+  ) => {
+    customMeals.setValue(
+      customMeals.value.map((val) =>
+        val.id === currentCustomData?.id
+          ? { ...val, location, name, price }
+          : val
+      )
+    );
+    setIsEditingCustomMeal(false);
+  };
+
+  useEffect(() => {
+    if (!currentCustomData) return;
+    setIsEditingCustomMeal(true);
+  }, [currentCustomData]);
 
   /**
    * Adds a meal to the queue.
@@ -32,8 +67,37 @@ const AvailableMeals = () => {
       meals={[...meals, ...customMeals.value]}
       buttonOnClick={addToQueue}
       createNotification={(name) => `Added ${name} to meal queue`}
-      includeCustomEditor={true}
+      onCustomClick={(data: Meal) => {
+        // If the custom data isn't changed, useEffect won't be triggered, but we don't have any new state
+        // so all we need to do is show the modal
+        if (currentCustomData === data) setIsEditingCustomMeal(true);
+        else setCurrentCustomData(data);
+      }}
     >
+      {
+        // This cannot work with only the 'visible' property because otherwise it will not re-render
+        // when we change its data
+        isEditingCustomMeal ? (
+          <CustomMealAddModal
+            startingData={currentCustomData}
+            onConfirm={onUpdateCustomMeal}
+            onCancel={() => {
+              setIsEditingCustomMeal(false);
+            }}
+            onDelete={() => {
+              customMeals.setValue(
+                customMeals.value.filter(
+                  (val) => val.id !== currentCustomData?.id
+                )
+              );
+              setIsEditingCustomMeal(false);
+            }}
+            visible={isEditingCustomMeal}
+          />
+        ) : (
+          <></>
+        )
+      }
       <CustomMeal />
     </MealContainer>
   );

--- a/src/static/context.ts
+++ b/src/static/context.ts
@@ -15,29 +15,40 @@ export const IsBreakCtx = createContext<ContextType<boolean>>({
   value: false,
   setValue: () => {}
 });
+
 export const MealPlanCtx = createContext<ContextType<boolean>>({
   value: false,
   setValue: () => {}
 });
+
 export const BalanceCtx = createContext<ContextType<number>>({
   value: 0,
   setValue: () => {}
 });
+
 export const StartDateCtx = createContext<ContextType<string>>({
   value: '',
   setValue: () => {}
 });
+
 export const EndDateCtx = createContext<ContextType<string>>({
   value: '',
   setValue: () => {}
 });
+
 export const UserSelectedMealsCtx = createContext<
   ContextType<UserSelectedMealsObjectType>
 >({
   value: new UserSelectedMealsObject(),
   setValue: () => {}
 });
+
 export const MealQueueCtx = createContext<ContextType<Meal[]>>({
+  value: [],
+  setValue: () => {}
+});
+
+export const CustomMealsCtx = createContext<ContextType<Meal[]>>({
   value: [],
   setValue: () => {}
 });

--- a/src/types/Meal.ts
+++ b/src/types/Meal.ts
@@ -1,5 +1,6 @@
 interface Meal {
   id?: string;
+  isCustom?: boolean;
   location: string;
   name: string;
   price: number;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,8 +19,7 @@ export default {
         inter: ['Inter', 'monospace']
       },
       dropShadow: {
-<<<<<<< HEAD
-        "dark": "0 2px 3px rgb(0 0 0 / 0.3)"
+        dark: '0 2px 3px rgb(0 0 0 / 0.3)'
       },
       keyframes: {
         topNotify: {
@@ -36,10 +35,7 @@ export default {
         }
       },
       animation: {
-        'topNotify': 'topNotify 2.5s ease'
-=======
-        dark: '0 2px 3px rgb(0 0 0 / 0.3)'
->>>>>>> 2f4ed60 (Added custom meal editor.)
+        topNotify: 'topNotify 2.5s ease'
       }
     }
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,25 +1,25 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",
-  ],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
       colors: {
-        "messiah-blue": "hsl(210, 57%, 24%)",
-        "messiah-blue-hover": "hsl(210, 57%, 34%)",
-        "messiah-blue-active": "hsl(210, 57%, 14%)",
-        "messiah-light-blue": "hsl(210, 20%, 70%)",
-        "messiah-light-blue-hover": "hsl(210, 20%, 80%)",
-        "messiah-light-blue-active": "hsl(210, 20%, 60%)",
-        "messiah-red": "hsl(359, 50%, 43%)",
-        "messiah-green": "hsl(173, 83%, 25%)"
+        'messiah-blue': 'hsl(210, 57%, 24%)',
+        'messiah-blue-hover': 'hsl(210, 57%, 34%)',
+        'messiah-blue-active': 'hsl(210, 57%, 14%)',
+        'messiah-light-blue': 'hsl(210, 20%, 70%)',
+        'messiah-light-blue-hover': 'hsl(210, 20%, 80%)',
+        'messiah-light-blue-active': 'hsl(210, 20%, 60%)',
+        'messiah-red': 'hsl(359, 50%, 43%)',
+        'messiah-red-hover': 'hsl(359, 50%, 53%)',
+        'messiah-red-active': 'hsl(359, 50%, 33%)',
+        'messiah-green': 'hsl(173, 83%, 25%)'
       },
       fontFamily: {
-        inter: ["Inter", "monospace"]
+        inter: ['Inter', 'monospace']
       },
       dropShadow: {
+<<<<<<< HEAD
         "dark": "0 2px 3px rgb(0 0 0 / 0.3)"
       },
       keyframes: {
@@ -37,9 +37,11 @@ export default {
       },
       animation: {
         'topNotify': 'topNotify 2.5s ease'
+=======
+        dark: '0 2px 3px rgb(0 0 0 / 0.3)'
+>>>>>>> 2f4ed60 (Added custom meal editor.)
       }
-    },
+    }
   },
-  plugins: [],
-}
-
+  plugins: []
+};


### PR DESCRIPTION
Implemented the custom meal editor, these meals now work just like anything else and can be edited and deleted, and they do persist. Note that editing a custom meal does NOT update it in the meal queue/day editor, but this is also true for normal meals at the moment due to the way our overall implementation works. Given this can be confusing, it may be worth changing in a future sprint, but it’s outside the scope of this PR.