### PR TITLE
New day selectors

### DIFF
--- a/src/components/containers/MealContainer.tsx
+++ b/src/components/containers/MealContainer.tsx
@@ -8,7 +8,8 @@ import SortingModal from '../modals/SortingModal';
 import Meal from '../../types/Meal';
 
 interface MealContainerProps {
-  title?: React.ReactNode;
+  title?: string;
+  daySelector?: React.ReactNode;
   addOrRemove?: string;
   customMeal?: boolean;
   children?: React.ReactNode;
@@ -26,6 +27,7 @@ const DEFAULT_DIRECTION = true;
 /**
  * A Container for sections with a meal table. Additional children of the section go under the meal table.
  * @param {string} title The title of the section
+ * @param {React.ReactNode} daySelector The day selector for the section, if applicable
  * @param {string} addOrRemove A string denoting whether the side buttons are add or remove buttons. Defaults to 'add'.
  * @param {React.ReactNode} children The children of the section.
  * @param {Meal[]} meals The list of meals to display
@@ -37,6 +39,7 @@ const DEFAULT_DIRECTION = true;
  */
 const MealContainer = ({
   title,
+  daySelector,
   addOrRemove = 'Add',
   children = '',
   meals,
@@ -56,8 +59,8 @@ const MealContainer = ({
   const [sortColumn, setSortColumn] = useState(DEFAULT_COLUMN);
 
   return (
-    <SectionContainer title={typeof title === 'string' ? title : ''}>
-      {typeof title === 'object' ? title : ''}
+    <SectionContainer title={title}>
+      {daySelector ?? <></>}
       <div className='absolute top-0 right-0'>
         <Button
           icon={sortDirection ? <FaSortAmountUp /> : <FaSortAmountDown />}

--- a/src/components/form_elements/DaySelector.tsx
+++ b/src/components/form_elements/DaySelector.tsx
@@ -5,28 +5,30 @@ const days = WEEKDAYS.map((day) => day.slice(0, 3));
 interface DaySelectorProps {
   daysSelected: boolean[];
   onChange: (i: number) => void;
-  maxWidth?: number;
+  square?: boolean;
 }
 
 /**
  * Component for a day selector, with each day in a circle that can be selected (and deselected)
- * @param {Object} props - Object with onChange function and list of selected days
+ * @param {Object} props - Object with onChange function and list of selected days, and square boolean
+ * to indicate if the selector should be square
  */
 const DaySelector = ({
   daysSelected,
   onChange,
-  maxWidth
+  square = false
 }: DaySelectorProps) => {
   return (
-    <div className='flex flex-row justify-center w-full gap-2'>
+    <div
+      className={`flex flex-row justify-center gap-2 ${!square && 'w-full'}`}
+    >
       {days.map((day, i) => (
-        <div
-          key={i}
-          className={`w-full ${maxWidth ? `max-w-${maxWidth}` : ''}`}
-        >
+        <div key={i} className={`flex-1 ${square && 'w-10'}`}>
           <button
             key={i}
-            className={`w-full p-1 h-10 rounded-lg items-center justify-center ${
+            className={`w-full p-1 h-10 ${
+              square && 'w-10'
+            } rounded-lg flex items-center justify-center ${
               daysSelected[i]
                 ? 'bg-messiah-light-blue sm:hover:bg-messiah-light-blue-hover active:bg-messiah-light-blue-active'
                 : 'bg-gray-300 sm:hover:bg-gray-200 active:bg-gray-400'

--- a/src/components/form_elements/DaySelector.tsx
+++ b/src/components/form_elements/DaySelector.tsx
@@ -11,9 +11,11 @@ interface DaySelectorProps {
 
 /**
  * Component for a day selector, with each day in a circle that can be selected (and deselected)
- * @param {Object} props - Object with onChange function and list of selected days, and square boolean
- * to indicate if the selector should be square, and numOfMeals to indicate the number of meals on the
- * each day (optional, not displayed if empty)
+ * @param {boolean[]} props.daysSelected - List of booleans indicating whether each day is selected or not
+ * @param {function} props.onChange - Function to call when a day is clicked, with the index of the day as an argument
+ * @param {boolean} [props.square=false] - Optional boolean indicating whether the selector should be square or not
+ * @param {number[]} [props.numOfMeals] - Optional list of numbers indicating the number of meals on each day
+ * @returns {JSX.Element} The DaySelector component
  */
 const DaySelector = ({
   daysSelected,

--- a/src/components/form_elements/DaySelector.tsx
+++ b/src/components/form_elements/DaySelector.tsx
@@ -1,0 +1,44 @@
+import { WEEKDAYS } from '../../static/constants';
+
+const days = WEEKDAYS.map((day) => day.slice(0, 3));
+
+interface DaySelectorProps {
+  daysSelected: boolean[];
+  onChange: (i: number) => void;
+  maxWidth?: number;
+}
+
+/**
+ * Component for a day selector, with each day in a circle that can be selected (and deselected)
+ * @param {Object} props - Object with onChange function and list of selected days
+ */
+const DaySelector = ({
+  daysSelected,
+  onChange,
+  maxWidth
+}: DaySelectorProps) => {
+  return (
+    <div className='flex flex-row justify-center w-full gap-2'>
+      {days.map((day, i) => (
+        <div
+          key={i}
+          className={`w-full ${maxWidth ? `max-w-${maxWidth}` : ''}`}
+        >
+          <button
+            key={i}
+            className={`w-full h-10 rounded-lg items-center justify-center ${
+              daysSelected[i]
+                ? 'bg-messiah-light-blue sm:hover:bg-messiah-light-blue-hover active:bg-messiah-light-blue-active'
+                : 'bg-gray-300 sm:hover:bg-gray-200 active:bg-gray-400'
+            }`}
+            onClick={() => onChange(i)}
+          >
+            <p className='text-14'>{day}</p>
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default DaySelector;

--- a/src/components/form_elements/DaySelector.tsx
+++ b/src/components/form_elements/DaySelector.tsx
@@ -12,7 +12,8 @@ interface DaySelectorProps {
 /**
  * Component for a day selector, with each day in a circle that can be selected (and deselected)
  * @param {Object} props - Object with onChange function and list of selected days, and square boolean
- * to indicate if the selector should be square
+ * to indicate if the selector should be square, and numOfMeals to indicate the number of meals on the
+ * each day (optional, not displayed if empty)
  */
 const DaySelector = ({
   daysSelected,
@@ -38,11 +39,16 @@ const DaySelector = ({
             onClick={() => onChange(i)}
           >
             <p className='text-14'>{day}</p>
-            {numOfMeals
-              ? <p className='text-xs font-extralight'>
-                  {numOfMeals[i]} <span className='hidden sm:inline'>meal{numOfMeals[i] !== 1 ? 's' : ''}</span>
-                </p>
-              : ''}
+            {numOfMeals ? (
+              <p className='text-xs font-extralight'>
+                {numOfMeals[i]}{' '}
+                <span className='hidden sm:inline'>
+                  meal{numOfMeals[i] !== 1 ? 's' : ''}
+                </span>
+              </p>
+            ) : (
+              ''
+            )}
           </button>
         </div>
       ))}

--- a/src/components/form_elements/DaySelector.tsx
+++ b/src/components/form_elements/DaySelector.tsx
@@ -26,7 +26,7 @@ const DaySelector = ({
         <div key={i} className={`flex-1 ${square && 'w-10'}`}>
           <button
             key={i}
-            className={`w-full p-1 h-10 ${
+            className={`w-full p-1 min-h-10 ${
               square && 'w-10'
             } rounded-lg flex items-center justify-center ${
               daysSelected[i]

--- a/src/components/form_elements/DaySelector.tsx
+++ b/src/components/form_elements/DaySelector.tsx
@@ -26,7 +26,7 @@ const DaySelector = ({
         >
           <button
             key={i}
-            className={`w-full h-10 rounded-lg items-center justify-center ${
+            className={`w-full p-1 h-10 rounded-lg items-center justify-center ${
               daysSelected[i]
                 ? 'bg-messiah-light-blue sm:hover:bg-messiah-light-blue-hover active:bg-messiah-light-blue-active'
                 : 'bg-gray-300 sm:hover:bg-gray-200 active:bg-gray-400'

--- a/src/components/form_elements/DaySelector.tsx
+++ b/src/components/form_elements/DaySelector.tsx
@@ -6,6 +6,7 @@ interface DaySelectorProps {
   daysSelected: boolean[];
   onChange: (i: number) => void;
   square?: boolean;
+  numOfMeals?: number[];
 }
 
 /**
@@ -16,7 +17,8 @@ interface DaySelectorProps {
 const DaySelector = ({
   daysSelected,
   onChange,
-  square = false
+  square = false,
+  numOfMeals
 }: DaySelectorProps) => {
   return (
     <div
@@ -28,7 +30,7 @@ const DaySelector = ({
             key={i}
             className={`w-full p-1 min-h-10 ${
               square && 'w-10'
-            } rounded-lg flex items-center justify-center ${
+            } rounded-lg flex flex-col items-center justify-center ${
               daysSelected[i]
                 ? 'bg-messiah-light-blue sm:hover:bg-messiah-light-blue-hover active:bg-messiah-light-blue-active'
                 : 'bg-gray-300 sm:hover:bg-gray-200 active:bg-gray-400'
@@ -36,6 +38,11 @@ const DaySelector = ({
             onClick={() => onChange(i)}
           >
             <p className='text-14'>{day}</p>
+            {numOfMeals
+              ? <p className='text-xs font-extralight'>
+                  {numOfMeals[i]} <span className='hidden sm:inline'>meal{numOfMeals[i] !== 1 ? 's' : ''}</span>
+                </p>
+              : ''}
           </button>
         </div>
       ))}

--- a/src/components/form_elements/DaySelector.tsx
+++ b/src/components/form_elements/DaySelector.tsx
@@ -35,8 +35,8 @@ const DaySelector = ({
               square && 'w-10'
             } rounded-lg flex flex-col items-center justify-center ${
               daysSelected[i]
-                ? 'bg-messiah-light-blue sm:hover:bg-messiah-light-blue-hover active:bg-messiah-light-blue-active'
-                : 'bg-gray-300 sm:hover:bg-gray-200 active:bg-gray-400'
+                ? 'bg-messiah-light-blue sm:hover:bg-messiah-light-blue-hover sm:active:bg-messiah-light-blue-active'
+                : 'bg-gray-300 sm:hover:bg-gray-200 sm:active:bg-gray-400'
             }`}
             onClick={() => onChange(i)}
           >

--- a/src/components/sections/DayEditor.tsx
+++ b/src/components/sections/DayEditor.tsx
@@ -104,7 +104,7 @@ const DayEditor = () => {
   return (
     <MealContainer
       title={
-        <div className='w-full'>
+        <div className='w-full bg-gray-300 rounded-lg'>
           <DaySelector
             daysSelected={new Array(7)
               .fill(false)

--- a/src/components/sections/DayEditor.tsx
+++ b/src/components/sections/DayEditor.tsx
@@ -103,8 +103,9 @@ const DayEditor = () => {
 
   return (
     <MealContainer
-      title={
-        <div className='w-full bg-gray-300 rounded-lg'>
+      title='Edit Days'
+      daySelector={
+        <div className='w-full bg-gray-300 rounded-lg mt-4'>
           <DaySelector
             daysSelected={new Array(7)
               .fill(false)

--- a/src/components/sections/DayEditor.tsx
+++ b/src/components/sections/DayEditor.tsx
@@ -1,7 +1,5 @@
 import { useContext, useMemo, useState } from 'react';
 import { WEEKDAYS } from '../../static/constants';
-import Select from '../form_elements/Select';
-import { newImportanceIndex } from '../../types/ImportanceIndex';
 import DotLeader from '../other/DotLeader';
 import {
   EndDateCtx,
@@ -18,6 +16,7 @@ import { CustomMealsCtx } from '../../static/context';
 import { getWeekdaysBetween } from '../../lib/dateCalcuation';
 import { getMealDayTotal } from '../../lib/calculationEngine';
 import formatCurrency from '../../lib/formatCurrency';
+import DaySelector from '../form_elements/DaySelector';
 
 /**
  * Renders a meal table for meals added to given days an an option to remove meals from that day.
@@ -84,11 +83,8 @@ const DayEditor = () => {
   const numOfWeekdays = useMemo(
     () =>
       startDate.value !== null && endDate.value !== null
-      ? getWeekdaysBetween(
-        startDate.value,
-        endDate.value,
-        weekOff.value)
-      : Array(7).fill(0),
+        ? getWeekdaysBetween(startDate.value, endDate.value, weekOff.value)
+        : Array(7).fill(0),
     [startDate, endDate, weekOff]
   );
 
@@ -108,18 +104,12 @@ const DayEditor = () => {
   return (
     <MealContainer
       title={
-        <div>
-          <Select
-            label=''
-            importance={newImportanceIndex(4)}
-            list={WEEKDAYS}
-            value={WEEKDAYS[weekdayIndex]}
-            setSelected={(newWeekday) =>
-              setWeekdayIndex(
-                WEEKDAYS.indexOf(newWeekday as (typeof WEEKDAYS)[number])
-              )
-            }
-            isTitle={true}
+        <div className='w-full'>
+          <DaySelector
+            daysSelected={new Array(7)
+              .fill(false)
+              .map((_, day) => day === weekdayIndex)}
+            onChange={setWeekdayIndex}
           />
         </div>
       }

--- a/src/components/sections/DayEditor.tsx
+++ b/src/components/sections/DayEditor.tsx
@@ -79,13 +79,20 @@ const DayEditor = () => {
     [dayMealList, discount.value]
   );
 
-  // The total number of days for each weekday (starting on Sunday)
+  /** The total number of days for each weekday (starting on Sunday) */
   const numOfWeekdays = useMemo(
     () =>
       startDate.value !== null && endDate.value !== null
         ? getWeekdaysBetween(startDate.value, endDate.value, weekOff.value)
         : Array(7).fill(0),
     [startDate, endDate, weekOff]
+  );
+
+  /** The total number of meals for each weekday (starting on Sunday). */
+  const numOfMeals = useMemo(
+    () =>
+      WEEKDAYS.map((day) => userSelectedMealsValue[day].length),
+    [userSelectedMealsValue]
   );
 
   /**
@@ -103,7 +110,7 @@ const DayEditor = () => {
 
   return (
     <MealContainer
-      title='Edit Days'
+      title='Day Editor'
       daySelector={
         <div className='w-full bg-gray-300 rounded-lg mt-4'>
           <DaySelector
@@ -111,6 +118,7 @@ const DayEditor = () => {
               .fill(false)
               .map((_, day) => day === weekdayIndex)}
             onChange={setWeekdayIndex}
+            numOfMeals={numOfMeals}
           />
         </div>
       }

--- a/src/components/sections/DayEditor.tsx
+++ b/src/components/sections/DayEditor.tsx
@@ -90,8 +90,7 @@ const DayEditor = () => {
 
   /** The total number of meals for each weekday (starting on Sunday). */
   const numOfMeals = useMemo(
-    () =>
-      WEEKDAYS.map((day) => userSelectedMealsValue[day].length),
+    () => WEEKDAYS.map((day) => userSelectedMealsValue[day].length),
     [userSelectedMealsValue]
   );
 
@@ -137,12 +136,12 @@ const DayEditor = () => {
           },
           {
             title: `Number of ${weekday}(s)`,
-            value: `${numOfWeekdays[(weekdayIndex + 1) % 7]}` // Convert from Monday to Sunday start
+            value: `${numOfWeekdays[weekdayIndex]}`
           },
           {
             title: `Total of All ${weekday}s`,
             value: `${formatCurrency(
-              mealDayTotal * numOfWeekdays[(weekdayIndex + 1) % 7] // Convert from Monday to Sunday start
+              mealDayTotal * numOfWeekdays[weekdayIndex] // Convert from Monday to Sunday start
             )}`,
             resultsStyle: 'text-messiah-red'
           }

--- a/src/components/sections/MealQueue.tsx
+++ b/src/components/sections/MealQueue.tsx
@@ -152,7 +152,7 @@ const MealQueue = () => {
               type: selectedDays.indexOf(i) === -1 ? 'add' : 'remove'
             })
           }
-          maxWidth={12}
+          square={true}
         />
       </div>
       <div className='flex gap-2 mt-4'>

--- a/src/components/sections/MealQueue.tsx
+++ b/src/components/sections/MealQueue.tsx
@@ -59,16 +59,16 @@ const MealQueue = () => {
   const onAddMeals = () => {
     userSelectedMeals.setValue(
       Object.fromEntries(
-        Object.entries(userSelectedMeals.value).map(
-          ([key, value], index: number) =>
+        WEEKDAYS.map(
+          (day, index: number) =>
             selectedDays.includes(index)
               ? [
-                  key,
-                  value.concat(
+                  day,
+                  userSelectedMeals.value[day].concat(
                     mealQueue.value.map((m) => ({ ...m, instanceId: uuid() }))
                   )
                 ]
-              : [key, value]
+              : [day, userSelectedMeals.value[day]]
         )
       ) as UserSelectedMealsObjectType
     );
@@ -119,7 +119,7 @@ const MealQueue = () => {
     },
     []
   );
-
+``
   /** Indicates whether the add meal button is disabled. */
   const isAddMealsButtonDisabled = useMemo(
     () => mealQueue.value.length == 0 || selectedDays.length == 0,

--- a/src/components/sections/MealQueue.tsx
+++ b/src/components/sections/MealQueue.tsx
@@ -1,5 +1,4 @@
-import { WEEKDAYS, WEEKDAY_ABBREVIATIONS } from '../../static/constants';
-import Input from '../form_elements/Input';
+import { WEEKDAYS } from '../../static/constants';
 import Button from '../form_elements/Button';
 import { useReducer, useContext, useMemo, useState } from 'react';
 import { MealQueueCtx, UserSelectedMealsCtx } from '../../static/context';
@@ -10,6 +9,7 @@ import { v4 as uuid } from 'uuid';
 import Notification from '../other/Notification';
 import meals from '../../static/mealsDatabase';
 import { CustomMealsCtx } from '../../static/context';
+import DaySelector from '../form_elements/DaySelector';
 
 /**
  * Renders the Meal Queue section, where meals in the queue can be added to different days of the week.
@@ -140,22 +140,20 @@ const MealQueue = () => {
       createNotification={(name) => `Removed ${name} from meal queue`}
     >
       <div className='mb-4' />
-      <div className='flex justify-center flex-wrap gap-6'>
-        {WEEKDAY_ABBREVIATIONS.map((day, i) => (
-          <Input
-            label={`${day}.`}
-            type='checkbox'
-            value={selectedDays.indexOf(i) !== -1}
-            setValue={(day) =>
-              selectedDaysDispatch({
-                index: i,
-                type: day ? 'add' : 'remove'
-              })
-            }
-            validator={(str) => str === 'true'}
-            key={day}
-          />
-        ))}
+      <p className='mb-2'>Add these meals to:</p>
+      <div className='flex justify-center flex-wrap gap-6 w-full'>
+        <DaySelector
+          daysSelected={new Array(7)
+            .fill(false)
+            .map((_v, i) => selectedDays.indexOf(i) !== -1)}
+          onChange={(i) =>
+            selectedDaysDispatch({
+              index: i,
+              type: selectedDays.indexOf(i) === -1 ? 'add' : 'remove'
+            })
+          }
+          maxWidth={12}
+        />
       </div>
       <div className='flex gap-2 mt-4'>
         <Button

--- a/src/components/sections/MealQueue.tsx
+++ b/src/components/sections/MealQueue.tsx
@@ -119,7 +119,7 @@ const MealQueue = () => {
     },
     []
   );
-``
+
   /** Indicates whether the add meal button is disabled. */
   const isAddMealsButtonDisabled = useMemo(
     () => mealQueue.value.length == 0 || selectedDays.length == 0,

--- a/src/lib/calculationEngine.ts
+++ b/src/lib/calculationEngine.ts
@@ -1,7 +1,7 @@
-import Meal from "../types/Meal";
-import { UserSelectedMealsObjectType } from "../types/userSelectedMealsObject";
-import { DISCOUNTS } from "../static/discounts";
-import { WEEKDAYS_START_SUNDAY } from "../static/constants";
+import Meal from '../types/Meal';
+import { UserSelectedMealsObjectType } from '../types/userSelectedMealsObject';
+import { DISCOUNTS } from '../static/discounts';
+import { WEEKDAYS } from '../static/constants';
 
 /**
  * Applies a discount to the meal price based on the location.
@@ -11,7 +11,9 @@ import { WEEKDAYS_START_SUNDAY } from "../static/constants";
  * @returns The discounted price of the meal.
  */
 export function applyDiscount(meal: Meal) {
-    return DISCOUNTS[meal.location] === undefined ? meal.price : meal.price * (1 - DISCOUNTS[meal.location]);    
+  return DISCOUNTS[meal.location] === undefined
+    ? meal.price
+    : meal.price * (1 - DISCOUNTS[meal.location]);
 }
 
 /**
@@ -24,9 +26,9 @@ export function applyDiscount(meal: Meal) {
  * @returns The total price for the given meals over the specified number of weekdays.
  */
 export function getMealDayTotal(meals: Meal[], days: number, discount = false) {
-    let total = 0;
-    meals.forEach(m => total += (discount? applyDiscount(m) : m.price));
-    return total * days;
+  let total = 0;
+  meals.forEach((m) => (total += discount ? applyDiscount(m) : m.price));
+  return total * days;
 }
 
 /**
@@ -37,12 +39,19 @@ export function getMealDayTotal(meals: Meal[], days: number, discount = false) {
  * @param searchMealList An array of meals to search from.
  * @returns The total of all the meals given the amount of weekdays
  */
-export function getMealTotal(userMeals: UserSelectedMealsObjectType, weekdays: number[], discount: boolean, searchMealList: Meal[]): number {
-    let total = 0;
-    WEEKDAYS_START_SUNDAY.forEach((day, i) => {
-        if (weekdays[i] === 0) return;
-        const mealList = userMeals[day].map(mr => searchMealList.find(m => m.id === mr.id) as Meal);
-        total += getMealDayTotal(mealList, weekdays[i], discount);
-    });
-    return total;
+export function getMealTotal(
+  userMeals: UserSelectedMealsObjectType,
+  weekdays: number[],
+  discount: boolean,
+  searchMealList: Meal[]
+): number {
+  let total = 0;
+  WEEKDAYS.forEach((day, i) => {
+    if (weekdays[i] === 0) return;
+    const mealList = userMeals[day].map(
+      (mr) => searchMealList.find((m) => m.id === mr.id) as Meal
+    );
+    total += getMealDayTotal(mealList, weekdays[i], discount);
+  });
+  return total;
 }

--- a/src/static/constants.ts
+++ b/src/static/constants.ts
@@ -8,24 +8,13 @@ export const IMPORTANCE_CLASSES = [
 ] as const;
 
 export const DINING_LOCATIONS = [
-  'Lottie', 
-  'Union', 
-  'Falcon', 
+  'Lottie',
+  'Union',
+  'Falcon',
   'Vending'
 ] as const;
 
-
 export const WEEKDAYS = [
-  'Monday',
-  'Tuesday',
-  'Wednesday',
-  'Thursday',
-  'Friday',
-  'Saturday',
-  'Sunday'
-] as const;
-
-export const WEEKDAYS_START_SUNDAY = [
   'Sunday',
   'Monday',
   'Tuesday',
@@ -34,42 +23,3 @@ export const WEEKDAYS_START_SUNDAY = [
   'Friday',
   'Saturday'
 ] as const;
-
-export const WEEKDAY_ABBREVIATIONS = [
-  'Mon',
-  'Tues',
-  'Wed',
-  'Thur',
-  'Fri',
-  'Sat',
-  'Sun'
-] as const;
-
-
-export const FILLER_MEALS = [
-  {
-    location: 'Home',
-    name: 'Cheeseburger and Fries',
-    price: 12.99
-  },
-  {
-    location: 'Work',
-    name: 'Hamburger and Fries',
-    price: 10.99
-  },
-  {
-    location: 'School',
-    name: 'Pizza and Fries',
-    price: 11.99
-  },
-  {
-    location: 'Home',
-    name: 'Salad and Fries',
-    price: 9.99
-  },
-  {
-    location: 'Work',
-    name: 'Pasta and Fries',
-    price: 12.99
-  }
-];

--- a/src/types/userSelectedMealsObject.ts
+++ b/src/types/userSelectedMealsObject.ts
@@ -5,13 +5,13 @@ import { WEEKDAYS } from '../static/constants';
  * This class is used with the userSelectedMeals context.
  */
 export class UserSelectedMealsObject {
+  Sunday: MealReference[] = [];
   Monday: MealReference[] = [];
   Tuesday: MealReference[] = [];
   Wednesday: MealReference[] = [];
   Thursday: MealReference[] = [];
   Friday: MealReference[] = [];
   Saturday: MealReference[] = [];
-  Sunday: MealReference[] = [];
 
   constructor() {
     WEEKDAYS.forEach((day) => {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 /** @type {import('tailwindcss').Config} */
+
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {


### PR DESCRIPTION
I found that even with changing the day selector to have the label and checkbox split on lines, it still wasn't even close to fitting across my phone, so I pulled in my DaySelector component from another app and modified it to fit this one. I also used the same component to switch the dropdown out for a tab bar, it looks a little silly at the moment because of the sort button but once we get it moved to the search bar row we should be good.