### PR TITLE
Refactored UserMealsObject and complicated logic around it

### DIFF
--- a/src/components/sections/DayEditor.tsx
+++ b/src/components/sections/DayEditor.tsx
@@ -17,6 +17,9 @@ import { getWeekdaysBetween } from '../../lib/dateCalcuation';
 import { getMealDayTotal } from '../../lib/calculationEngine';
 import formatCurrency from '../../lib/formatCurrency';
 import DaySelector from '../form_elements/DaySelector';
+import { Weekday } from '../../types/userSelectedMealsObject';
+import mapUserMeals from '../../lib/mapUserMeals';
+import dereferenceMeal from '../../lib/dereferenceMeal';
 
 /**
  * Renders a meal table for meals added to given days an an option to remove meals from that day.
@@ -32,27 +35,14 @@ const DayEditor = () => {
   // Dereference the userSelectedMeals context
   const userSelectedMealsValue = useMemo(
     () =>
-      Object.fromEntries(
-        Object.entries(userSelectedMeals.value).map(
-          ([key, value]) =>
-            [
-              key,
-              value
-                .map(
-                  (mr) =>
-                    ({
-                      // Load meal data
-                      ...[...meals, ...customMeals.value].find(
-                        (m) => m.id === mr.id
-                      ),
-
-                      // Assign the instance id
-                      instanceId: mr.instanceId
-                    } as Meal)
-                )
-                .filter((m) => m !== undefined)
-            ] as [string, Meal[]]
-        )
+      mapUserMeals(
+        (day: Weekday) =>
+          [
+            day,
+            userSelectedMeals.value[day]
+              .map((mr) => dereferenceMeal(mr, meals, customMeals.value))
+              .filter((m) => m !== undefined)
+          ] as [string, Meal[]]
       ),
     [userSelectedMeals, customMeals]
   );
@@ -65,7 +55,7 @@ const DayEditor = () => {
 
   // Get the list of selected meals for the given day
   const dayMealList = useMemo(
-    () => userSelectedMealsValue[WEEKDAYS[weekdayIndex]] ?? [],
+    () => (userSelectedMealsValue[WEEKDAYS[weekdayIndex]] as Meal[]) ?? [],
     [userSelectedMealsValue, weekdayIndex]
   );
 

--- a/src/lib/dereferenceMeal.ts
+++ b/src/lib/dereferenceMeal.ts
@@ -1,0 +1,28 @@
+import MealReference from '../types/MealReference';
+import Meal from '../types/Meal';
+
+/**
+ * Given a MealReference and arrays of meals and custom meals,
+ * returns a new Meal object with the data from the referenced meal
+ * and the provided instanceId.
+ *
+ * @param {MealReference} mr - The MealReference to be dereferenced.
+ * @param {Meal[]} meals - An array of Meal objects representing regular meals.
+ * @param {Meal[]} customMeals - An array of Meal objects representing custom meals.
+ * @return {Meal} A new Meal object with the data from the referenced meal
+ * and the provided instanceId.
+ */
+const dereferenceMeal = (
+  mr: MealReference,
+  meals: Meal[],
+  customMeals: Meal[]
+): Meal =>
+  ({
+    // Load meal data
+    ...[...meals, ...customMeals].find((m) => m.id === mr.id),
+
+    // Assign the instance id
+    instanceId: mr.instanceId
+  } as Meal);
+
+export default dereferenceMeal;

--- a/src/lib/mapUserMeals.ts
+++ b/src/lib/mapUserMeals.ts
@@ -1,0 +1,19 @@
+import { WEEKDAYS } from '../static/constants';
+import Meal from '../types/Meal';
+import MealReference from '../types/MealReference';
+import { Weekday } from '../types/userSelectedMealsObject';
+
+/**
+ * Generates a UserSelectedMealsObjectType object by mapping over the WEEKDAYS array and
+ * applying the given function to each element.
+ *
+ * @param {function(day: Weekday, index: number): [string, MealReference[] | Meal[]]} fn - The function
+ * to apply to each element of WEEKDAYS. The function takes in a day and its index, and returns
+ * a tuple containing a string key and either an array of MealReferences or Meals.
+ * @return {UserSelectedMealsObjectType} - The resulting UserSelectedMealsObjectType object.
+ */
+const mapUserMeals = (
+  fn: (day: Weekday, index: number) => [string, MealReference[] | Meal[]]
+) => Object.fromEntries(WEEKDAYS.map(fn));
+
+export default mapUserMeals;

--- a/src/test/dereferenceMeal.test.ts
+++ b/src/test/dereferenceMeal.test.ts
@@ -1,0 +1,74 @@
+import dereferenceMeal from '../lib/dereferenceMeal';
+import { describe, expect, it } from 'vitest';
+import MealReference from '../types/MealReference';
+import Meal from '../types/Meal';
+
+const fakeMeals = [
+  {
+    id: '1',
+    name: 'Lunch',
+    price: 8.99,
+    location: 'Lottie'
+  } as Meal,
+  {
+    id: '2',
+    name: 'Dinner',
+    price: 12.99,
+    location: 'Lottie'
+  } as Meal
+];
+
+const fakeCustomMeals = [
+  {
+    id: '3',
+    instanceId: '1',
+    name: 'Lunch',
+    price: 8.99,
+    location: 'Lottie'
+  } as Meal,
+  {
+    id: '4',
+    instanceId: '2',
+    name: 'Dinner',
+    price: 12.99,
+    location: 'Lottie'
+  } as Meal
+];
+
+describe('dereferenceMeal', () => {
+  it('should convert a MealReference to a Meal and override instanceId', () => {
+    expect(
+      dereferenceMeal(
+        {
+          id: '1',
+          instanceId: '1'
+        } as MealReference,
+        fakeMeals,
+        fakeCustomMeals
+      )
+    ).toStrictEqual({
+      id: '1',
+      name: 'Lunch',
+      price: 8.99,
+      location: 'Lottie',
+      instanceId: '1'
+    } as Meal);
+
+    expect(
+      dereferenceMeal(
+        {
+          id: '3',
+          instanceId: '2'
+        } as MealReference,
+        fakeMeals,
+        fakeCustomMeals
+      )
+    ).toStrictEqual({
+      id: '3',
+      instanceId: '2',
+      name: 'Lunch',
+      price: 8.99,
+      location: 'Lottie'
+    } as Meal);
+  });
+});

--- a/src/test/mapUserMeals.test.ts
+++ b/src/test/mapUserMeals.test.ts
@@ -1,0 +1,143 @@
+import mapUserMeals from '../lib/mapUserMeals';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { v4 as uuid } from 'uuid';
+import { Weekday } from '../types/userSelectedMealsObject';
+
+// Mocking the uuid function to return predictable values
+vi.mock('uuid', () => ({
+  v4: vi.fn()
+}));
+
+const selectedDays = [0, 1, 2, 3, 4, 5, 6];
+const userSelectedMeals = {
+  value: {
+    Monday: [
+      { id: '1', instanceId: '1' },
+      { id: '2', instanceId: '2' }
+    ],
+    Tuesday: [
+      { id: '3', instanceId: '3' },
+      { id: '4', instanceId: '4' }
+    ],
+    Wednesday: [
+      { id: '5', instanceId: '5' },
+      { id: '6', instanceId: '6' }
+    ],
+    Thursday: [
+      { id: '7', instanceId: '7' },
+      { id: '8', instanceId: '8' }
+    ],
+    Friday: [
+      { id: '9', instanceId: '9' },
+      { id: '10', instanceId: '10' }
+    ],
+    Saturday: [
+      { id: '11', instanceId: '11' },
+      { id: '12', instanceId: '12' }
+    ],
+    Sunday: [
+      { id: '13', instanceId: '13' },
+      { id: '14', instanceId: '14' }
+    ]
+  }
+};
+const mealQueue = {
+  value: [
+    {
+      id: '15'
+    },
+    {
+      id: '16'
+    }
+  ]
+};
+
+describe('mapUserMeals', () => {
+  beforeEach(() => {
+    // Reset the mocked uuid function before each test
+    vi.mocked(uuid).mockReset();
+  });
+
+  it('should return an object with 7 keys', () => {
+    expect(Object.keys(mapUserMeals((day) => [day, []])).length).toBe(7);
+  });
+
+  it('should return an object with the correct keys and values', () => {
+    // Mocking the uuid function to return specific values in sequence
+    vi.mocked(uuid)
+      .mockReturnValueOnce('mock-uuid-1')
+      .mockReturnValueOnce('mock-uuid-2')
+      .mockReturnValueOnce('mock-uuid-3')
+      .mockReturnValueOnce('mock-uuid-4')
+      .mockReturnValueOnce('mock-uuid-5')
+      .mockReturnValueOnce('mock-uuid-6')
+      .mockReturnValueOnce('mock-uuid-7')
+      .mockReturnValueOnce('mock-uuid-8')
+      .mockReturnValueOnce('mock-uuid-9')
+      .mockReturnValueOnce('mock-uuid-10')
+      .mockReturnValueOnce('mock-uuid-11')
+      .mockReturnValueOnce('mock-uuid-12')
+      .mockReturnValueOnce('mock-uuid-13')
+      .mockReturnValueOnce('mock-uuid-14');
+
+    const result = mapUserMeals((day: Weekday, index: number) =>
+      selectedDays.includes(index)
+        ? [
+            day,
+            userSelectedMeals.value[day].concat(
+              mealQueue.value.map((m) => ({ ...m, instanceId: uuid() }))
+            )
+          ]
+        : [day, userSelectedMeals.value[day]]
+    );
+
+    expect(result).toStrictEqual({
+      Sunday: [
+        { id: '13', instanceId: '13' },
+        { id: '14', instanceId: '14' },
+        { id: '15', instanceId: 'mock-uuid-1' },
+        { id: '16', instanceId: 'mock-uuid-2' }
+      ],
+      Monday: [
+        { id: '1', instanceId: '1' },
+        { id: '2', instanceId: '2' },
+        { id: '15', instanceId: 'mock-uuid-3' },
+        { id: '16', instanceId: 'mock-uuid-4' }
+      ],
+      Tuesday: [
+        { id: '3', instanceId: '3' },
+        { id: '4', instanceId: '4' },
+        { id: '15', instanceId: 'mock-uuid-5' },
+        { id: '16', instanceId: 'mock-uuid-6' }
+      ],
+      Wednesday: [
+        { id: '5', instanceId: '5' },
+        { id: '6', instanceId: '6' },
+        { id: '15', instanceId: 'mock-uuid-7' },
+        { id: '16', instanceId: 'mock-uuid-8' }
+      ],
+      Thursday: [
+        { id: '7', instanceId: '7' },
+        { id: '8', instanceId: '8' },
+        { id: '15', instanceId: 'mock-uuid-9' },
+        { id: '16', instanceId: 'mock-uuid-10' }
+      ],
+      Friday: [
+        { id: '9', instanceId: '9' },
+        { id: '10', instanceId: '10' },
+        { id: '15', instanceId: 'mock-uuid-11' },
+        { id: '16', instanceId: 'mock-uuid-12' }
+      ],
+      Saturday: [
+        { id: '11', instanceId: '11' },
+        { id: '12', instanceId: '12' },
+        { id: '15', instanceId: 'mock-uuid-13' },
+        { id: '16', instanceId: 'mock-uuid-14' }
+      ]
+    });
+
+    // Further debugging output if needed
+    expect(result).toHaveProperty('Monday');
+    expect(result.Monday).toHaveLength(4);
+  });
+});

--- a/src/test/mapUserMeals.test.ts
+++ b/src/test/mapUserMeals.test.ts
@@ -2,11 +2,84 @@ import mapUserMeals from '../lib/mapUserMeals';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { v4 as uuid } from 'uuid';
 import { Weekday } from '../types/userSelectedMealsObject';
+import dereferenceMeal from '../lib/dereferenceMeal';
+import Meal from '../types/Meal';
 
 // Mocking the uuid function to return predictable values
 vi.mock('uuid', () => ({
   v4: vi.fn()
 }));
+
+const meals = [
+  { id: '1', instanceId: '1', name: 'Lunch', price: 8.99, location: 'Lottie' },
+  {
+    id: '2',
+    instanceId: '2',
+    name: 'Dinner',
+    price: 12.99,
+    location: 'Lottie'
+  },
+  { id: '3', instanceId: '3', name: 'Lunch', price: 8.99, location: 'Lottie' },
+  {
+    id: '4',
+    instanceId: '4',
+    name: 'Dinner',
+    price: 12.99,
+    location: 'Lottie'
+  },
+  { id: '5', instanceId: '5', name: 'Lunch', price: 8.99, location: 'Lottie' },
+  {
+    id: '6',
+    instanceId: '6',
+    name: 'Dinner',
+    price: 12.99,
+    location: 'Lottie'
+  },
+  { id: '7', instanceId: '7', name: 'Lunch', price: 8.99, location: 'Lottie' },
+  {
+    id: '8',
+    instanceId: '8',
+    name: 'Dinner',
+    price: 12.99,
+    location: 'Lottie'
+  },
+  { id: '9', instanceId: '9', name: 'Lunch', price: 8.99, location: 'Lottie' },
+  {
+    id: '10',
+    instanceId: '10',
+    name: 'Dinner',
+    price: 12.99,
+    location: 'Lottie'
+  },
+  {
+    id: '11',
+    instanceId: '11',
+    name: 'Lunch',
+    price: 8.99,
+    location: 'Lottie'
+  },
+  {
+    id: '12',
+    instanceId: '12',
+    name: 'Dinner',
+    price: 12.99,
+    location: 'Lottie'
+  },
+  {
+    id: '13',
+    instanceId: '13',
+    name: 'Lunch',
+    price: 8.99,
+    location: 'Lottie'
+  },
+  {
+    id: '14',
+    instanceId: '14',
+    name: 'Dinner',
+    price: 12.99,
+    location: 'Lottie'
+  }
+];
 
 const selectedDays = [0, 1, 2, 3, 4, 5, 6];
 const userSelectedMeals = {
@@ -52,6 +125,23 @@ const mealQueue = {
   ]
 };
 
+const customMeals = {
+  value: [
+    {
+      id: '20',
+      location: 'Lottie',
+      name: 'Lunch',
+      price: 8.99
+    } as Meal,
+    {
+      id: '21',
+      location: 'Lottie',
+      name: 'Dinner',
+      price: 12.99
+    } as Meal
+  ]
+};
+
 describe('mapUserMeals', () => {
   beforeEach(() => {
     // Reset the mocked uuid function before each test
@@ -62,7 +152,134 @@ describe('mapUserMeals', () => {
     expect(Object.keys(mapUserMeals((day) => [day, []])).length).toBe(7);
   });
 
-  it('should return an object with the correct keys and values', () => {
+  it('should return an object with the correct keys and values when used in dayEditor', () => {
+    const result = mapUserMeals(
+      (day: Weekday) =>
+        [
+          day,
+          userSelectedMeals.value[day]
+            .map((mr) => dereferenceMeal(mr, meals, customMeals.value))
+            .filter((m) => m !== undefined)
+        ] as [string, Meal[]]
+    );
+
+    expect(result).toEqual({
+      Sunday: [
+        {
+          id: '13',
+          instanceId: '13',
+          name: 'Lunch',
+          price: 8.99,
+          location: 'Lottie'
+        },
+        {
+          id: '14',
+          instanceId: '14',
+          name: 'Dinner',
+          price: 12.99,
+          location: 'Lottie'
+        }
+      ],
+      Monday: [
+        {
+          id: '1',
+          instanceId: '1',
+          name: 'Lunch',
+          price: 8.99,
+          location: 'Lottie'
+        },
+        {
+          id: '2',
+          instanceId: '2',
+          name: 'Dinner',
+          price: 12.99,
+          location: 'Lottie'
+        }
+      ],
+      Tuesday: [
+        {
+          id: '3',
+          instanceId: '3',
+          name: 'Lunch',
+          price: 8.99,
+          location: 'Lottie'
+        },
+        {
+          id: '4',
+          instanceId: '4',
+          name: 'Dinner',
+          price: 12.99,
+          location: 'Lottie'
+        }
+      ],
+      Wednesday: [
+        {
+          id: '5',
+          instanceId: '5',
+          name: 'Lunch',
+          price: 8.99,
+          location: 'Lottie'
+        },
+        {
+          id: '6',
+          instanceId: '6',
+          name: 'Dinner',
+          price: 12.99,
+          location: 'Lottie'
+        }
+      ],
+      Thursday: [
+        {
+          id: '7',
+          instanceId: '7',
+          name: 'Lunch',
+          price: 8.99,
+          location: 'Lottie'
+        },
+        {
+          id: '8',
+          instanceId: '8',
+          name: 'Dinner',
+          price: 12.99,
+          location: 'Lottie'
+        }
+      ],
+      Friday: [
+        {
+          id: '9',
+          instanceId: '9',
+          name: 'Lunch',
+          price: 8.99,
+          location: 'Lottie'
+        },
+        {
+          id: '10',
+          instanceId: '10',
+          name: 'Dinner',
+          price: 12.99,
+          location: 'Lottie'
+        }
+      ],
+      Saturday: [
+        {
+          id: '11',
+          instanceId: '11',
+          name: 'Lunch',
+          price: 8.99,
+          location: 'Lottie'
+        },
+        {
+          id: '12',
+          instanceId: '12',
+          name: 'Dinner',
+          price: 12.99,
+          location: 'Lottie'
+        }
+      ]
+    });
+  });
+
+  it('should return an object with the correct keys and values when used in mealQueue', () => {
     // Mocking the uuid function to return specific values in sequence
     vi.mocked(uuid)
       .mockReturnValueOnce('mock-uuid-1')
@@ -135,9 +352,5 @@ describe('mapUserMeals', () => {
         { id: '16', instanceId: 'mock-uuid-14' }
       ]
     });
-
-    // Further debugging output if needed
-    expect(result).toHaveProperty('Monday');
-    expect(result.Monday).toHaveLength(4);
   });
 });

--- a/src/types/userSelectedMealsObject.ts
+++ b/src/types/userSelectedMealsObject.ts
@@ -18,3 +18,6 @@ export class UserSelectedMealsObject {
 export type UserSelectedMealsObjectType = {
   [K in (typeof WEEKDAYS)[number]]: MealReference[];
 };
+
+// Type for keys
+export type Weekday = (typeof WEEKDAYS)[number];

--- a/src/types/userSelectedMealsObject.ts
+++ b/src/types/userSelectedMealsObject.ts
@@ -5,19 +5,16 @@ import { WEEKDAYS } from '../static/constants';
  * This class is used with the userSelectedMeals context.
  */
 export class UserSelectedMealsObject {
-  [key: string]: MealReference[];
-
-  constructor() {
-    WEEKDAYS.forEach((day) => {
-      this[day] = [];
-    });
-  }
+  Sunday: MealReference[] = [];
+  Monday: MealReference[] = [];
+  Tuesday: MealReference[] = [];
+  Wednesday: MealReference[] = [];
+  Thursday: MealReference[] = [];
+  Friday: MealReference[] = [];
+  Saturday: MealReference[] = [];
 }
 
 // Type alias for the class
 export type UserSelectedMealsObjectType = {
   [K in (typeof WEEKDAYS)[number]]: MealReference[];
 };
-
-// Type for keys
-export type Weekday = (typeof WEEKDAYS)[number];

--- a/src/types/userSelectedMealsObject.ts
+++ b/src/types/userSelectedMealsObject.ts
@@ -5,13 +5,7 @@ import { WEEKDAYS } from '../static/constants';
  * This class is used with the userSelectedMeals context.
  */
 export class UserSelectedMealsObject {
-  Sunday: MealReference[] = [];
-  Monday: MealReference[] = [];
-  Tuesday: MealReference[] = [];
-  Wednesday: MealReference[] = [];
-  Thursday: MealReference[] = [];
-  Friday: MealReference[] = [];
-  Saturday: MealReference[] = [];
+  [key: string]: MealReference[];
 
   constructor() {
     WEEKDAYS.forEach((day) => {

--- a/src/types/userSelectedMealsObject.ts
+++ b/src/types/userSelectedMealsObject.ts
@@ -14,7 +14,11 @@ export class UserSelectedMealsObject {
   Saturday: MealReference[] = [];
 }
 
-// Type alias for the class
+/** 
+ * Type alias for the UserSelectedMealsObject class.
+*/
 export type UserSelectedMealsObjectType = {
   [K in (typeof WEEKDAYS)[number]]: MealReference[];
 };
+
+export type Weekday =  typeof WEEKDAYS[number];


### PR DESCRIPTION
I changed UserMealsObject so that it can just rely on WEEKDAYS for its properties. I also refactored the logic of mapping over it and extracted two functions, mapUserMeals and dereferenceMeal, to make it easier to understand. Unit tests for these functions are included.