### PR TITLE
Added ability to add directly to days

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "uuid": "^9.0.1"
       },
       "devDependencies": {
+        "@types/node": "^20.14.10",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
         "@types/uuid": "^9.0.8",
@@ -1146,6 +1147,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.14.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
@@ -4509,6 +4519,12 @@
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.3.tgz",
       "integrity": "sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==",
+      "dev": true
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
+    "@types/node": "^20.14.10",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@types/uuid": "^9.0.8",

--- a/src/components/containers/MealContainer.tsx
+++ b/src/components/containers/MealContainer.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { IoAdd, IoRemove } from 'react-icons/io5';
 import Meal from '../../types/Meal';
 import { TutorialObject } from '../../static/tutorial';
+import { Weekday } from '../../types/userSelectedMealsObject';
 
 interface MealContainerProps {
   title?: string;
@@ -13,7 +14,9 @@ interface MealContainerProps {
   children?: React.ReactNode;
   meals: Meal[];
   buttonOnClick: (meal: Meal) => unknown;
+  buttonOnClickDay?: (day: Weekday, meal: Meal) => void;
   createNotification: (name: string) => string;
+  createDayNotification?: (day: Weekday, name: string) => string;
   onCustomClick?: (data: Meal) => void;
   newCustomMealID?: string;
   searchable?: boolean;
@@ -28,7 +31,9 @@ interface MealContainerProps {
  * @param {React.ReactNode} children The children of the section.
  * @param {Meal[]} meals The list of meals to display
  * @param {(index: Meal) => unkown} buttonOnClick Handle the add or remove button click
- * @param {(string) => string} notificationMessage - A function that takes in the meal name and returns the notification message when the meal button is clicked.
+ * @param {(day: Weekday, meal: Meal) => void} buttonOnClickDay - The click event handler for the day button
+ * @param {() => string} createNotification - A function that takes in the meal name and returns the notification message
+ * @param {() => string} createDayNotification - A function that takes in the meal name and returns the notification message for adding direct to day
  * @param {() => void} onCustomClick - The click event handler for editing a custom meal
  * @param {string | undefined} newCustomMealID - The ID of the newly added custom meal to scroll to
  * @param {boolean} searchable - Whether the table should be searchable
@@ -42,7 +47,9 @@ const MealContainer = ({
   children = '',
   meals,
   buttonOnClick,
+  buttonOnClickDay,
   createNotification,
+  createDayNotification,
   onCustomClick,
   newCustomMealID,
   searchable = true,
@@ -56,7 +63,9 @@ const MealContainer = ({
         buttonTitle={addOrRemove}
         buttonIcon={addOrRemove === 'Add' ? <IoAdd /> : <IoRemove />}
         buttonOnClick={buttonOnClick}
+        buttonOnClickDay={buttonOnClickDay}
         createNotification={createNotification}
+        createDayNotification={createDayNotification}
         onCustomClick={onCustomClick}
         newCustomMealID={newCustomMealID}
         searchable={searchable}

--- a/src/components/containers/table/ButtonCell.tsx
+++ b/src/components/containers/table/ButtonCell.tsx
@@ -1,28 +1,149 @@
+import { IoAdd } from 'react-icons/io5';
+import { useEffect, useRef, useState } from 'react';
+import { WEEKDAYS } from '../../../static/constants';
+import { Weekday } from '../../../types/userSelectedMealsObject';
+import useLongPress from '../../../hooks/useLongPress';
+import useClickOutside from '../../../hooks/useClickOutside';
+
 interface ButtonCellProps {
   icon: JSX.Element;
   onClick: () => void;
+  onClickDay?: (day: Weekday) => void;
 }
 
 /**
  * Renders a table cell with a button that triggers the provided onClick function when clicked
+ * and the provided onClickDay function when a day button is clicked
  *
  * @param {JSX.Element} icon - The component for the icon to display on the button
  * @param {() => void} onClick - The function to be called when the button is clicked
+ * @param {() => void} onClickDay - The function to be called when a day button is clicked
  * @returns {JSX.Element} The rendered table cell with a button
  */
 const ButtonCell = ({
   icon,
-  onClick = () => {}
-}: ButtonCellProps): JSX.Element => (
-  <td className='text-center'>
-    <button
-      className='bg-messiah-light-blue hover:bg-messiah-light-blue-hover active:bg-messiah-light-blue-active
-      text-black text-lg font-bold w-8 h-8 m-2 rounded-full text-center transition duration-50'
-      onClick={onClick}
-    >
-      <div className='flex justify-center items-center'>{icon}</div>
-    </button>
-  </td>
-);
+  onClick = () => {},
+  onClickDay = () => {}
+}: ButtonCellProps): JSX.Element => {
+  /**
+   * State for whether the button is hovered
+   * This and the next state together control whether the button should be expanded to show the day buttons
+   * Note this is only shown when the icon is IoAdd (the icon for an 'add' button)
+   */
+  const [isButtonHovered, setIsButtonHovered] = useState(false);
+  /**
+   * State for whether the tooltip is hovered
+   */
+  const [isTooltipHovered, setIsTooltipHovered] = useState(false);
+  /**
+   * State to keep track of button rounding
+   */
+  const [isRounded, setIsRounded] = useState(true);
+
+  /**
+   * Detector for whether or not the user is on a mobile device
+   * @returns {boolean} Whether the current device is a mobile device
+   */
+  const isMobileDevice = () => /Mobi|Android/i.test(navigator.userAgent);
+
+  /**
+   * Ref to the button container, for handling outside click on mobile
+   */
+  const ref = useRef<HTMLDivElement>(null);
+
+  /**
+   * Use long press for mobile
+   */
+  const handleLongPress = useLongPress(
+    isMobileDevice() && icon.type == IoAdd
+      ? () => {
+          setIsTooltipHovered(true);
+        }
+      : () => {},
+    isMobileDevice() && icon.type == IoAdd ? onClick : () => {},
+    300
+  );
+
+  /** Use outside click for mobile */
+  useClickOutside(ref, () => {
+    setIsTooltipHovered(false);
+  });
+
+  /**
+   * useEffect to keep track of button rounding
+   */
+  useEffect(() => {
+    if (!isButtonHovered && !isTooltipHovered) {
+      const timer = setTimeout(() => setIsRounded(false), 300); // Match the transition duration
+      return () => clearTimeout(timer);
+    } else {
+      setIsRounded(true);
+    }
+  }, [isButtonHovered, isTooltipHovered]);
+
+  return (
+    <td className='text-center'>
+      <div className='flex items-center h-full justify-center'>
+        <div
+          className='relative flex items-center justify-center h-full'
+          ref={isMobileDevice() ? ref : null}
+        >
+          <button
+            {...handleLongPress}
+            className={`bg-messiah-light-blue hover:bg-messiah-light-blue-hover active:bg-messiah-light-blue-active
+                 text-black text-lg font-bold w-8 h-8 my-2 mx-0 select-none ${
+                   isRounded
+                     ? 'rounded-full rounded-tl-none rounded-bl-none'
+                     : 'rounded-full'
+                 } text-center transition duration-50`}
+            onClick={
+              !isMobileDevice() || icon.type !== IoAdd ? onClick : () => {}
+            }
+            onMouseEnter={
+              icon.type === IoAdd && !isMobileDevice()
+                ? () => setIsButtonHovered(true)
+                : () => {}
+            }
+            onMouseLeave={
+              icon.type === IoAdd && !isMobileDevice()
+                ? () => setIsButtonHovered(false)
+                : () => {}
+            }
+          >
+            <div className='flex justify-center items-center'>{icon}</div>
+          </button>
+          <div
+            className={`flex absolute right-full top-1/2 transform -translate-y-1/2 transition-all duration-300 
+            ${
+              isButtonHovered || isTooltipHovered
+                ? 'w-60 bg-messiah-light-blue'
+                : 'w-0 bg-messiah-light-blue-hover'
+            } z-10 h-8 rounded-tl-full rounded-bl-full overflow-hidden`}
+            onMouseEnter={
+              icon.type === IoAdd && !isMobileDevice()
+                ? () => setIsTooltipHovered(true)
+                : () => {}
+            }
+            onMouseLeave={
+              icon.type === IoAdd && !isMobileDevice()
+                ? () => setIsTooltipHovered(false)
+                : () => {}
+            }
+          >
+            {WEEKDAYS.map((day) => (
+              <button
+                key={day}
+                className='w-full h-full hover:bg-messiah-light-blue-hover transition duration-50 select-none'
+                onClick={() => onClickDay(day)}
+              >
+                {day.slice(0, 2)}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </td>
+  );
+};
 
 export default ButtonCell;

--- a/src/components/containers/table/ButtonCell.tsx
+++ b/src/components/containers/table/ButtonCell.tsx
@@ -91,7 +91,7 @@ const ButtonCell = ({
           <button
             {...handleLongPress}
             className={`bg-messiah-light-blue hover:bg-messiah-light-blue-hover active:bg-messiah-light-blue-active
-                 text-black text-lg font-bold w-8 h-8 my-2 mx-0 select-none ${
+                 text-black text-lg font-bold w-8 h-8 my-2 mx-0 select-none z-10 ${
                    isRounded
                      ? 'rounded-full rounded-tl-none rounded-bl-none'
                      : 'rounded-full'

--- a/src/components/containers/table/MealTable.tsx
+++ b/src/components/containers/table/MealTable.tsx
@@ -11,13 +11,16 @@ import { filterMeals } from '../../../lib/filterMeals';
 import { newImportanceIndex } from '../../../types/ImportanceIndex';
 import SortBy from '../../../types/SortBy';
 import Meal from '../../../types/Meal';
+import { Weekday } from '../../../types/userSelectedMealsObject';
 
 interface MealTableProps {
   data: Array<Meal>;
   buttonIcon?: JSX.Element;
   buttonTitle?: string;
   buttonOnClick: (meal: Meal) => void;
+  buttonOnClickDay?: (day: Weekday, meal: Meal) => void;
   createNotification: (name: string) => string;
+  createDayNotification?: (day: Weekday, name: string) => string;
   onCustomClick?: (data: Meal) => void;
   newCustomMealID?: string;
   searchable?: boolean;
@@ -30,7 +33,9 @@ interface MealTableProps {
  * @param {string} buttonTitle - The title of the optional button column
  * @param {JSX.Element} buttonIcon - The icon for the optional button
  * @param {(Meal) => void} buttonOnClick - The click event handler for the optional button
- * @param {(string) => string} notificationMessage - A function that takes in the meal name and returns the notification message when the meal button is clicked.
+ * @param {(day: Weekday) => void} buttonOnClickDay - The click event handler for the optional day button
+ * @param {() => string} createNotification - A function that takes in the meal name and returns the notification message
+ * @param {() => string} createDayNotification - A function that takes in the meal name and returns the notification message for adding direct to day
  * @param {() => void} onCustomClick - The click event handler for editing a custom meal
  * @param {string | undefined} newCustomMealID - The ID of the newly added custom meal to scroll to
  * @param {boolean} searchable - Whether the table should be searchable
@@ -41,7 +46,9 @@ const MealTable = ({
   buttonIcon,
   buttonTitle,
   buttonOnClick,
+  buttonOnClickDay,
   createNotification,
+  createDayNotification,
   onCustomClick,
   newCustomMealID,
   searchable = true
@@ -70,6 +77,13 @@ const MealTable = ({
   const handleButtonClick = (row: Meal) => {
     buttonOnClick(row);
     setMessage({ text: createNotification(row.name) });
+  };
+
+  const handleDayButtonClick = (day: Weekday, row: Meal) => {
+    buttonOnClickDay?.(day, row);
+    setMessage({
+      text: createDayNotification ? createDayNotification(day, row.name) : ''
+    });
   };
 
   /**
@@ -167,9 +181,9 @@ const MealTable = ({
             filteredAndSortedData.length > 0 ? '' : 'hidden'
           }`}
         >
-          <table className='w-full [&_tr>td:nth-child(-n+2)]:text-left [&_tr>td:nth-child(n+3)]:text-right relative'>
+          <table className='w-full [&_tr>td:nth-child(-n+2)]:text-left [&_tr>td:nth-child(n+3)]:text-center relative'>
             {/* Table header */}
-            <thead className='sticky top-0 bg-white drop-shadow-dark'>
+            <thead className='sticky top-0 bg-white drop-shadow-dark z-10'>
               <tr>
                 {headers.map((header, index) =>
                   header !== null ? (
@@ -203,6 +217,9 @@ const MealTable = ({
                   data={row}
                   buttonIcon={buttonIcon}
                   buttonOnClick={() => handleButtonClick(row)}
+                  buttonOnClickDay={(day: Weekday) =>
+                    handleDayButtonClick(day, row)
+                  }
                   onCustomClick={onCustomClick}
                   newCustomMealID={newCustomMealID}
                 />

--- a/src/components/containers/table/MealTable.tsx
+++ b/src/components/containers/table/MealTable.tsx
@@ -183,7 +183,7 @@ const MealTable = ({
         >
           <table className='w-full [&_tr>td:nth-child(-n+2)]:text-left [&_tr>td:nth-child(n+3)]:text-center relative'>
             {/* Table header */}
-            <thead className='sticky top-0 bg-white drop-shadow-dark z-10'>
+            <thead className='sticky top-0 bg-white drop-shadow-dark z-20'>
               <tr>
                 {headers.map((header, index) =>
                   header !== null ? (

--- a/src/components/containers/table/TableRow.tsx
+++ b/src/components/containers/table/TableRow.tsx
@@ -6,11 +6,13 @@ import formatCurrency from '../../../lib/formatCurrency';
 import { useContext, useEffect, useMemo, useRef } from 'react';
 import { MealPlanCtx } from '../../../static/context';
 import { applyDiscount } from '../../../lib/calculationEngine';
+import { Weekday } from '../../../types/userSelectedMealsObject';
 
 interface TableRowProps {
   data: Meal;
   buttonIcon?: JSX.Element;
   buttonOnClick?: () => void;
+  buttonOnClickDay?: (day: Weekday) => void;
   onCustomClick?: (data: Meal) => void;
   newCustomMealID?: string;
 }
@@ -21,6 +23,7 @@ interface TableRowProps {
  * @param {Meal} data - The data for the table row
  * @param {JSX.Element} buttonIcon - The icon for the button
  * @param {() => void} buttonOnClick - The click event handler for the button
+ * @param {(day: Weekday) => void} buttonOnClickDay - The click event handler for the day button
  * @param {() => void} onCustomClick - The click event handler for editing a custom meal
  * @param {string} newCustomMealID - The ID of the newly added custom meal to be scrolled to
  * @return {JSX.Element} The rendered table row.
@@ -29,14 +32,16 @@ const TableRow = ({
   data,
   buttonIcon,
   buttonOnClick,
+  buttonOnClickDay,
   onCustomClick,
-  newCustomMealID,
+  newCustomMealID
 }: TableRowProps): JSX.Element => {
   const isMealPlan = useContext(MealPlanCtx);
 
   const price = useMemo(
-    () => isMealPlan.value ? applyDiscount(data) : data.price, 
-    [data, isMealPlan.value]);
+    () => (isMealPlan.value ? applyDiscount(data) : data.price),
+    [data, isMealPlan.value]
+  );
 
   const tr = useRef<HTMLTableRowElement>(null);
 
@@ -45,8 +50,8 @@ const TableRow = ({
       tr.current.scrollIntoView({
         behavior: 'smooth',
         block: 'center'
-    });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [newCustomMealID]);
 
   return (
@@ -59,7 +64,9 @@ const TableRow = ({
           isCustom={data.isCustom}
           importance={newImportanceIndex(2)}
           onCustomClick={
-            onCustomClick !== undefined && data.isCustom ? () => onCustomClick(data) : undefined
+            onCustomClick !== undefined && data.isCustom
+              ? () => onCustomClick(data)
+              : undefined
           }
         />
         <TableCell
@@ -67,7 +74,11 @@ const TableRow = ({
           importance={newImportanceIndex(2)}
         />
         {buttonIcon && buttonOnClick ? (
-          <ButtonCell icon={buttonIcon} onClick={buttonOnClick} />
+          <ButtonCell
+            icon={buttonIcon}
+            onClick={buttonOnClick}
+            onClickDay={buttonOnClickDay}
+          />
         ) : (
           <></>
         )}

--- a/src/components/form_elements/Input.tsx
+++ b/src/components/form_elements/Input.tsx
@@ -72,10 +72,7 @@ const Input = <T,>({
 
   /** The title attribute of the input tag. */
   const titleAttribute = useMemo(
-    () =>
-      label
-        ? label.replace(/[^(\s|\w)]/g, '').trim()
-        : 'input',
+    () => (label ? label.replace(/[^(\s|\w)]/g, '').trim() : 'input'),
     [label]
   );
 
@@ -99,7 +96,9 @@ const Input = <T,>({
   return (
     <div className='text-left w-full'>
       <label
-        className={`${importanceStyle} w-max flex flex-row flex-wrap gap-2 items-center`}
+        className={`${importanceStyle} ${
+          styles.includes('w-full') ? 'w-full' : 'w-max'
+        } flex flex-row flex-wrap gap-2 items-center`}
       >
         {label || ''}
         {type === 'checkbox' ? (

--- a/src/components/sections/AvailableMeals.tsx
+++ b/src/components/sections/AvailableMeals.tsx
@@ -2,11 +2,16 @@ import meals from '../../static/mealsDatabase';
 import Meal from '../../types/Meal';
 import MealContainer from '../containers/MealContainer';
 import CustomMeal from '../other/CustomMeal';
-import { CustomMealsCtx, MealQueueCtx } from '../../static/context';
+import {
+  CustomMealsCtx,
+  MealQueueCtx,
+  UserSelectedMealsCtx
+} from '../../static/context';
 import { useContext, useEffect, useState } from 'react';
 import { v4 as uuid } from 'uuid';
 import tutorial from '../../static/tutorial';
 import CustomMealAddModal from '../modals/CustomMealAddModal';
+import { Weekday } from '../../types/userSelectedMealsObject';
 
 /**
  * Renders the Available Meals section with a table of meals to add and a button
@@ -18,6 +23,7 @@ const AvailableMeals = () => {
   // Load all necessary contexts
   const mealQueue = useContext(MealQueueCtx);
   const customMeals = useContext(CustomMealsCtx);
+  const userSelectedMeals = useContext(UserSelectedMealsCtx);
 
   // State variable to determine whether or not the custom meal modal should be open
   const [isEditingCustomMeal, setIsEditingCustomMeal] = useState(false);
@@ -68,13 +74,31 @@ const AvailableMeals = () => {
     ]);
   };
 
+  /**
+   * Adds a meal directly to the selected day.
+   *
+   * @param {Weekday} day - The day to add the meal to.
+   * @param {Meal} meal - The meal to be added to the day.
+   */
+  const addToDay = (day: Weekday, meal: Meal) => {
+    userSelectedMeals.setValue({
+      ...userSelectedMeals.value,
+      [day]: [
+        ...(userSelectedMeals.value[day] ?? []),
+        { ...meal, instanceId: uuid() }
+      ]
+    });
+  };
+
   return (
     <MealContainer
       title='Available Meals'
       addOrRemove='Add'
       meals={[...meals, ...customMeals.value]}
       buttonOnClick={addToQueue}
+      buttonOnClickDay={addToDay}
       createNotification={(name) => `Added ${name} to meal queue`}
+      createDayNotification={(day, name) => `Added ${name} directly to ${day}`}
       onCustomClick={(data: Meal) => {
         // If the custom data isn't changed, useEffect won't be triggered, but we don't have any new state
         // so all we need to do is show the modal

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,0 +1,27 @@
+import { RefObject, useEffect } from 'react';
+/**
+ * Hook that triggers a callback when a click occurs outside a specified element.
+ *
+ * @param ref - Reference to the HTMLElement to detect clicks outside of.
+ * @param onClickOutside - Callback function to trigger when a click occurs outside the element.
+ */
+
+const useClickOutside = (
+  ref: RefObject<HTMLElement>,
+  onClickOutside: () => void
+) => {
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        onClickOutside();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [ref, onClickOutside]);
+};
+
+export default useClickOutside;

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * A hook that detects a long press event on a component.
+ *
+ * @param {function} onLongPress - The function to be called when the long press event is detected
+ * @param {function} [onClick] - The function to be called when the component is clicked (optional)
+ * @param {number} [delay=300] - The delay in milliseconds before the long press event is detected (optional, default is 300)
+ * @returns {object} An object with two properties: `onMouseDown` and `onMouseUp`. These should be passed to the component as props.
+ */
+const useLongPress = (
+  onLongPress: () => void,
+  onClick?: () => void,
+  delay = 300
+) => {
+  const timer = useRef<NodeJS.Timeout | null>(null);
+  const isLongPress = useRef(false);
+
+  const handleMouseDown = () => {
+    isLongPress.current = false; // Reset the flag
+    timer.current = setTimeout(() => {
+      isLongPress.current = true;
+      onLongPress();
+      if ('vibrate' in navigator) {
+        navigator.vibrate(100); // Vibrate for 100 milliseconds
+      }
+    }, delay);
+  };
+
+  const handleMouseUp = () => {
+    // No action on mouse up for short clicks
+  };
+
+  const handleTouchStart = () => {
+    isLongPress.current = false; // Reset the flag
+    timer.current = setTimeout(() => {
+      isLongPress.current = true;
+      onLongPress();
+      if ('vibrate' in navigator) {
+        navigator.vibrate(100);
+      }
+    }, delay);
+  };
+
+  const handleTouchEnd = () => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      if (!isLongPress.current && onClick) {
+        onClick(); // Call onClick only if it wasn't a long press
+      }
+    }
+  };
+
+  const handleClick = (event: React.MouseEvent | React.TouchEvent) => {
+    // Prevent onClick from firing if it's a long press
+    if (isLongPress.current) {
+      event.preventDefault();
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timer.current) {
+        clearTimeout(timer.current);
+      }
+    };
+  }, []);
+
+  return {
+    onMouseDown: handleMouseDown,
+    onMouseUp: handleMouseUp,
+    onTouchStart: handleTouchStart,
+    onTouchEnd: handleTouchEnd,
+    onClick: handleClick
+  };
+};
+
+export default useLongPress;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,9 @@ export default {
         'messiah-red-active': 'hsl(359, 50%, 33%)',
         'messiah-green': 'hsl(173, 83%, 25%)'
       },
+      overflow: {
+        visible: 'visible'
+      },
       fontFamily: {
         inter: ['Inter', 'monospace']
       },


### PR DESCRIPTION
I added the add button tooltips. I decided I wanted to minimize the number of clicks/taps to get meals into the queue, so I went with separate behaviors on mobile and desktop: on desktop, the tooltip shows on hover, on mobile, you long press the button. Note that while the long press is supposed to trigger a vibration, iOS doesn't support it so I can't really test it.