### PR TITLE
MMP-118: Update to support new a la carte plans

### DIFF
--- a/src/components/containers/table/MealTable.tsx
+++ b/src/components/containers/table/MealTable.tsx
@@ -1,7 +1,5 @@
 import { Fragment, useMemo, useState } from 'react';
 import { FaListUl, FaUser } from 'react-icons/fa';
-import { v4 as uuid } from 'uuid';
-import Highlighter from '../../other/Highlighter';
 import Input from '../../form_elements/Input';
 import Notification from '../../other/Notification';
 import TableCell from './TableCell';
@@ -12,6 +10,7 @@ import { newImportanceIndex } from '../../../types/ImportanceIndex';
 import SortBy from '../../../types/SortBy';
 import Meal from '../../../types/Meal';
 import { Weekday } from '../../../types/userSelectedMealsObject';
+import Switch from '../../form_elements/Switch';
 
 interface MealTableProps {
   /**
@@ -167,14 +166,9 @@ const MealTable = ({
     setSortDirection(sortColumn === header ? !sortDirection : true);
   };
 
-  /**
-   * The HTML ID of the day selector
-   */
-  const daySelectorId = `dayselector-${uuid()}`;
-
   return (
     <>
-      <div id={daySelectorId} className='relative w-full'>
+      <div className='relative w-full'>
         <div
           className={`${
             data.length === 0 ? 'hidden' : ''
@@ -201,38 +195,11 @@ const MealTable = ({
             </div>
 
             {/* Custom meal filter */}
-            <div className='text-sm h-full bg-gray-300 rounded-lg flex relative z-5'>
-              <button
-                id={`dayselector-${daySelectorId}-0`}
-                onClick={() => setCustomOnly(false)}
-                className={`relative flex flex-row items-center justify-center h-full rounded-lg p-[5px] ${
-                  customOnly
-                    ? 'sm:hover:bg-messiah-light-blue-hover'
-                    : 'bg-transparent hover:bg-transparent active:bg-transparent'
-                } transition duration-50 z-20`}
-              >
-                <FaListUl className='p-2' size={30} />
-                <span className='hidden sm:inline'>All&nbsp;</span>
-              </button>
-              <button
-                id={`dayselector-${daySelectorId}-1`}
-                onClick={() => setCustomOnly(true)}
-                className={`relative flex flex-row items-center justify-center h-full rounded-lg p-[5px] ${
-                  customOnly
-                    ? 'bg-transparent hover:bg-transparent active:bg-transparent'
-                    : 'sm:hover:bg-messiah-light-blue-hover'
-                } transition duration-50 z-20`}
-              >
-                <FaUser className='p-2' size={30} />
-                <span className='hidden sm:inline text-nowrap'>
-                  Custom Only&nbsp;
-                </span>
-              </button>
-            </div>
-            <Highlighter
-              selectedIndex={customOnly ? 1 : 0}
-              daySelectorId={daySelectorId}
-              offsetTop={-16}
+            <Switch
+              state={customOnly}
+              setState={setCustomOnly}
+              offIcon={<FaListUl />}
+              onIcon={<FaUser />}
             />
           </div>
         </div>

--- a/src/components/containers/table/MealTable.tsx
+++ b/src/components/containers/table/MealTable.tsx
@@ -200,6 +200,8 @@ const MealTable = ({
               setState={setCustomOnly}
               offIcon={<FaListUl />}
               onIcon={<FaUser />}
+              offText='All'
+              onText='Custom Only'
             />
           </div>
         </div>

--- a/src/components/containers/table/MealTable.tsx
+++ b/src/components/containers/table/MealTable.tsx
@@ -202,6 +202,7 @@ const MealTable = ({
               onIcon={<FaUser />}
               offText='All'
               onText='Custom Only'
+              shrinkable={true}
             />
           </div>
         </div>

--- a/src/components/containers/table/TableRow.tsx
+++ b/src/components/containers/table/TableRow.tsx
@@ -7,6 +7,7 @@ import { useContext, useEffect, useMemo, useRef } from 'react';
 import { MealPlanCtx } from '../../../static/context';
 import { applyDiscount } from '../../../lib/calculationEngine';
 import { Weekday } from '../../../types/userSelectedMealsObject';
+import { ALACARTE_DISCOUNT } from '../../../static/discounts';
 
 interface TableRowProps {
   /**
@@ -64,7 +65,10 @@ const TableRow = ({
    * The price of the meal based on whether or not the DD meal plan discount is enabled
    */
   const price = useMemo(
-    () => (isMealPlan.value ? applyDiscount(data) : data.price * 0.9),
+    () =>
+      isMealPlan.value
+        ? applyDiscount(data)
+        : data.price * (1 - ALACARTE_DISCOUNT),
     [data, isMealPlan.value]
   );
 

--- a/src/components/containers/table/TableRow.tsx
+++ b/src/components/containers/table/TableRow.tsx
@@ -64,7 +64,7 @@ const TableRow = ({
    * The price of the meal based on whether or not the DD meal plan discount is enabled
    */
   const price = useMemo(
-    () => (isMealPlan.value ? applyDiscount(data) : data.price),
+    () => (isMealPlan.value ? applyDiscount(data) : data.price * 0.9),
     [data, isMealPlan.value]
   );
 

--- a/src/components/form_elements/Switch.tsx
+++ b/src/components/form_elements/Switch.tsx
@@ -20,9 +20,19 @@ interface SwitchProps {
   offIcon: JSX.Element;
 
   /**
+   * The text to display on the "off" side of the switch.
+   */
+  offText: string;
+
+  /**
    * The icon to display on the "on" side of the switch.
    */
   onIcon: JSX.Element;
+
+  /**
+   * The text to display on the "on" side of the switch.
+   */
+  onText: string;
 }
 
 /**
@@ -31,7 +41,14 @@ interface SwitchProps {
  * @param {SwitchProps} props - The props for the Switch component.
  * @returns {JSX.Element} The Switch component.
  */
-const Switch = ({ state, setState, offIcon, onIcon }: SwitchProps) => {
+const Switch = ({
+  state,
+  setState,
+  offIcon,
+  offText,
+  onIcon,
+  onText
+}: SwitchProps) => {
   const id = `dayselector-${uuid()}`;
 
   return (
@@ -49,7 +66,7 @@ const Switch = ({ state, setState, offIcon, onIcon }: SwitchProps) => {
           <IconContext.Provider value={{ className: 'p-2', size: '30px' }}>
             {offIcon}
           </IconContext.Provider>
-          <span className='hidden sm:inline'>All&nbsp;</span>
+          <span className='hidden sm:inline'>{offText}&nbsp;</span>
         </button>
         <button
           id={`dayselector-${id}-1`}
@@ -63,9 +80,7 @@ const Switch = ({ state, setState, offIcon, onIcon }: SwitchProps) => {
           <IconContext.Provider value={{ className: 'p-2', size: '30px' }}>
             {onIcon}
           </IconContext.Provider>
-          <span className='hidden sm:inline text-nowrap'>
-            Custom Only&nbsp;
-          </span>
+          <span className='hidden sm:inline text-nowrap'>{onText}&nbsp;</span>
         </button>
       </div>
       <Highlighter

--- a/src/components/form_elements/Switch.tsx
+++ b/src/components/form_elements/Switch.tsx
@@ -1,0 +1,80 @@
+import Highlighter from '../other/Highlighter';
+import { IconContext } from 'react-icons';
+import { v4 as uuid } from 'uuid';
+
+interface SwitchProps {
+  /**
+   * The current state of the switch.
+   */
+  state: boolean;
+
+  /**
+   * Sets the state of the switch.
+   * @param {boolean} state - The new state of the switch.
+   */
+  setState: (state: boolean) => void;
+
+  /**
+   * The icon to display on the "off" side of the switch.
+   */
+  offIcon: JSX.Element;
+
+  /**
+   * The icon to display on the "on" side of the switch.
+   */
+  onIcon: JSX.Element;
+}
+
+/**
+ * Component for a switch that can be toggled between two states.
+ *
+ * @param {SwitchProps} props - The props for the Switch component.
+ * @returns {JSX.Element} The Switch component.
+ */
+const Switch = ({ state, setState, offIcon, onIcon }: SwitchProps) => {
+  const id = `dayselector-${uuid()}`;
+
+  return (
+    <div className='relative' id={id}>
+      <div className='text-sm h-full bg-gray-300 rounded-lg flex relative z-5'>
+        <button
+          id={`dayselector-${id}-0`}
+          onClick={() => setState(false)}
+          className={`relative flex flex-row items-center justify-center h-full rounded-lg p-[5px] ${
+            state
+              ? 'sm:hover:bg-messiah-light-blue-hover'
+              : 'bg-transparent hover:bg-transparent active:bg-transparent'
+          } transition duration-50 z-20`}
+        >
+          <IconContext.Provider value={{ className: 'p-2', size: '30px' }}>
+            {offIcon}
+          </IconContext.Provider>
+          <span className='hidden sm:inline'>All&nbsp;</span>
+        </button>
+        <button
+          id={`dayselector-${id}-1`}
+          onClick={() => setState(true)}
+          className={`relative flex flex-row items-center justify-center h-full rounded-lg p-[5px] ${
+            state
+              ? 'bg-transparent hover:bg-transparent active:bg-transparent'
+              : 'sm:hover:bg-messiah-light-blue-hover'
+          } transition duration-50 z-20`}
+        >
+          <IconContext.Provider value={{ className: 'p-2', size: '30px' }}>
+            {onIcon}
+          </IconContext.Provider>
+          <span className='hidden sm:inline text-nowrap'>
+            Custom Only&nbsp;
+          </span>
+        </button>
+      </div>
+      <Highlighter
+        selectedIndex={state ? 1 : 0}
+        daySelectorId={id}
+        offsetTop={0}
+      />
+    </div>
+  );
+};
+
+export default Switch;

--- a/src/components/form_elements/Switch.tsx
+++ b/src/components/form_elements/Switch.tsx
@@ -17,7 +17,7 @@ interface SwitchProps {
   /**
    * The icon to display on the "off" side of the switch.
    */
-  offIcon: JSX.Element;
+  offIcon?: JSX.Element;
 
   /**
    * The text to display on the "off" side of the switch.
@@ -27,12 +27,17 @@ interface SwitchProps {
   /**
    * The icon to display on the "on" side of the switch.
    */
-  onIcon: JSX.Element;
+  onIcon?: JSX.Element;
 
   /**
    * The text to display on the "on" side of the switch.
    */
   onText: string;
+
+  /**
+   * Whether or not the switch should shrink for small screeens.
+   */
+  shrinkable?: boolean;
 }
 
 /**
@@ -44,10 +49,11 @@ interface SwitchProps {
 const Switch = ({
   state,
   setState,
-  offIcon,
+  offIcon = <></>,
   offText,
-  onIcon,
-  onText
+  onIcon = <></>,
+  onText,
+  shrinkable = false
 }: SwitchProps) => {
   const id = `dayselector-${uuid()}`;
 
@@ -66,7 +72,11 @@ const Switch = ({
           <IconContext.Provider value={{ className: 'p-2', size: '30px' }}>
             {offIcon}
           </IconContext.Provider>
-          <span className='hidden sm:inline'>{offText}&nbsp;</span>
+          <span
+            className={`${shrinkable ? 'hidden sm:' : ''}inline text-nowrap`}
+          >
+            {offText}&nbsp;
+          </span>
         </button>
         <button
           id={`dayselector-${id}-1`}
@@ -80,7 +90,11 @@ const Switch = ({
           <IconContext.Provider value={{ className: 'p-2', size: '30px' }}>
             {onIcon}
           </IconContext.Provider>
-          <span className='hidden sm:inline text-nowrap'>{onText}&nbsp;</span>
+          <span
+            className={`${shrinkable ? 'hidden sm:' : ''}inline text-nowrap`}
+          >
+            {onText}&nbsp;
+          </span>
         </button>
       </div>
       <Highlighter

--- a/src/components/sections/MealPlanInfo.tsx
+++ b/src/components/sections/MealPlanInfo.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../static/context';
 import { dateInputToDate, getDaysBetween } from '../../lib/dateCalcuation';
 import tooltip from '../../static/tooltip';
+import Switch from '../form_elements/Switch';
 
 interface MealPlanInfoProps {
   /**
@@ -97,14 +98,15 @@ const MealPlanInfo = ({
           }
           invalidMessage={'End date must be after start date.'}
         />
-
-        <Input
-          label={'Dining Dollars Discount:'}
-          type={'checkbox'}
-          value={mealPlan.value}
-          setValue={mealPlan.setValue}
-          validator={(str) => str === 'true'}
-        />
+        <div className='flex flex-row items-center'>
+          <div className='w-[130px]'>Meal Plan Type: </div>
+          <Switch
+            state={mealPlan.value ?? false}
+            setState={mealPlan.setValue}
+            offText='A La Carte'
+            onText='Dining Dollars'
+          />
+        </div>
         <Input
           label={'Number of weeks off: '}
           type={'number'}

--- a/src/lib/calculationEngine.ts
+++ b/src/lib/calculationEngine.ts
@@ -26,12 +26,13 @@ export function applyDiscount(meal: Meal) {
  *
  * @param meals - An array of meal objects.
  * @param days - The number of weekdays for which to calculate the total price.
- * @param discount - A boolean flag indicating whether to apply a discount to the meal prices.
+ * @param discount - A boolean flag indicating whether to apply the DD discount to the meal prices.
+ *  If false, uses the 10% A La Carte Discount.
  * @returns The total price for the given meals over the specified number of weekdays.
  */
 export function getMealDayTotal(meals: Meal[], days: number, discount = false) {
   let total = 0;
-  meals.forEach((m) => (total += discount ? applyDiscount(m) : m.price));
+  meals.forEach((m) => (total += discount ? applyDiscount(m) : m.price * 0.9));
   return total * days;
 }
 

--- a/src/lib/calculationEngine.ts
+++ b/src/lib/calculationEngine.ts
@@ -3,7 +3,7 @@ import {
   UserSelectedMealsObjectType,
   Weekday
 } from '../types/userSelectedMealsObject';
-import { DISCOUNTS } from '../static/discounts';
+import { ALACARTE_DISCOUNT, DISCOUNTS } from '../static/discounts';
 import { WEEKDAYS } from '../static/constants';
 import { getAllDatesBetween } from './dateCalcuation';
 
@@ -32,7 +32,10 @@ export function applyDiscount(meal: Meal) {
  */
 export function getMealDayTotal(meals: Meal[], days: number, discount = false) {
   let total = 0;
-  meals.forEach((m) => (total += discount ? applyDiscount(m) : m.price * 0.9));
+  meals.forEach(
+    (m) =>
+      (total += discount ? applyDiscount(m) : m.price * (1 - ALACARTE_DISCOUNT))
+  );
   return total * days;
 }
 

--- a/src/lib/mealChartFormat.ts
+++ b/src/lib/mealChartFormat.ts
@@ -4,6 +4,7 @@ import { UserSelectedMealsObjectType } from '../types/userSelectedMealsObject';
 import dereferenceMeal from './dereferenceMeal';
 import Meal from '../types/Meal';
 import { applyDiscount } from './calculationEngine';
+import { ALACARTE_DISCOUNT } from '../static/discounts';
 
 /**
  * This function takes in a UserSelectedMealsObject and returns data for a stacked chart of the total cost of each meal.
@@ -34,7 +35,9 @@ export function userMealsToStackedChart(
       mealList.forEach((meal) => {
         const n = locationMap.get(meal.location) ?? [];
 
-        n[i] += isDiscount ? applyDiscount(meal) : meal.price * 0.9;
+        n[i] += isDiscount
+          ? applyDiscount(meal)
+          : meal.price * (1 - ALACARTE_DISCOUNT);
         locationMap.set(meal.location, n);
       });
     }

--- a/src/lib/mealChartFormat.ts
+++ b/src/lib/mealChartFormat.ts
@@ -34,7 +34,7 @@ export function userMealsToStackedChart(
       mealList.forEach((meal) => {
         const n = locationMap.get(meal.location) ?? [];
 
-        n[i] += isDiscount ? applyDiscount(meal) : meal.price;
+        n[i] += isDiscount ? applyDiscount(meal) : meal.price * 0.9;
         locationMap.set(meal.location, n);
       });
     }

--- a/src/static/discounts.ts
+++ b/src/static/discounts.ts
@@ -1,14 +1,16 @@
 export type Discounts = {
-    [key: string]: number;
-    Lottie: number;
-    Union: number;
-    Falcon: number;
-    CafeDiem: number;
-}
+  [key: string]: number;
+  Lottie: number;
+  Union: number;
+  Falcon: number;
+  CafeDiem: number;
+};
 
 export const DISCOUNTS: Discounts = {
-    'Lottie': .52,
-    'Union': .3,
-    'Falcon': .3,
-    'CafeDiem': .3,
+  Lottie: 0.52,
+  Union: 0.3,
+  Falcon: 0.3,
+  CafeDiem: 0.3
 };
+
+export const ALACARTE_DISCOUNT = 0.1;

--- a/src/static/tooltip.tsx
+++ b/src/static/tooltip.tsx
@@ -67,8 +67,8 @@ const tooltip = {
             move out at the end of the semester.
           </li>
           <li>
-            <strong>Dining Dollars Discount:</strong> Check this if you use the
-            Dining Dollars plan, with the discount.
+            <strong>Meal Plan Type:</strong> Set this to the type of meal plan
+            you have, it will be used in calculating the discount.
           </li>
           <li>
             <strong>Number of Weeks off:</strong> Enter the number of weeks you

--- a/src/static/tutorialSteps.tsx
+++ b/src/static/tutorialSteps.tsx
@@ -61,10 +61,10 @@ const tutorialSteps: TutorialStep[] = [
         . If this is your first semester, here is some info to help:
         <ul className='list-disc ml-5'>
           <li>
-            If you live in the residence halls, check the "Dining Dollars
-            Discount."
+            If you live in the residence halls, set the meal plan type to
+            "Dining Dollars".
           </li>
-          <li>Set the starting balance to 1200.</li>
+          <li>Set the starting balance to 1145.</li>
         </ul>
       </div>
     ),

--- a/src/test/calculationEngine.test.ts
+++ b/src/test/calculationEngine.test.ts
@@ -9,6 +9,7 @@ import meals from '../static/mealsDatabase';
 import MealReference from '../types/MealReference';
 import { UserSelectedMealsObjectType } from '../types/userSelectedMealsObject';
 import Meal from '../types/Meal';
+import { ALACARTE_DISCOUNT } from '../static/discounts';
 
 describe('applyDiscount', () => {
   it('should work for Lottie', () => {
@@ -36,12 +37,12 @@ describe('getMealDayTotal', () => {
 
   it('should work', () => {
     expect(getMealDayTotal(mealList, 1)).toBeCloseTo(
-      (6.55 + 4.5 + 8 + 2.25) * 0.9,
+      (6.55 + 4.5 + 8 + 2.25) * (1 - ALACARTE_DISCOUNT),
       2
     );
 
     expect(getMealDayTotal(mealList, 2)).toBeCloseTo(
-      (6.55 + 4.5 + 8 + 2.25) * 2 * 0.9,
+      (6.55 + 4.5 + 8 + 2.25) * 2 * (1 - ALACARTE_DISCOUNT),
       1
     );
   });
@@ -87,16 +88,16 @@ describe('getMealTotal', () => {
   it('should work for 1 day', () => {
     expect(
       getMealTotal(userMeals, [0, 1, 0, 0, 0, 0, 0], false, meals) // mealList1
-    ).toBeCloseTo((6.55 + 8) * 0.9, 2);
+    ).toBeCloseTo((6.55 + 8) * (1 - ALACARTE_DISCOUNT), 2);
     expect(
       getMealTotal(userMeals, [1, 0, 0, 0, 0, 0, 0], false, meals) // mealList2
-    ).toBeCloseTo(6.75 * 0.9, 2);
+    ).toBeCloseTo(6.75 * (1 - ALACARTE_DISCOUNT), 2);
   });
 
   it('should work for multiple days', () => {
     expect(
       getMealTotal(userMeals, [1, 1, 0, 0, 0, 0, 0], false, meals)
-    ).toBeCloseTo((6.55 + 8 + 6.75) * 0.9, 2);
+    ).toBeCloseTo((6.55 + 8 + 6.75) * (1 - ALACARTE_DISCOUNT), 2);
   });
 
   it('should work for discount', () => {

--- a/src/test/calculationEngine.test.ts
+++ b/src/test/calculationEngine.test.ts
@@ -27,7 +27,7 @@ describe('applyDiscount', () => {
 describe('getMealDayTotal', () => {
   const mealList = meals.filter((m) =>
     [
-      'Breakfast', // 6.3
+      'Breakfast', // 6.55
       'Smash Burger', // 4.15
       'Grain Bowl', // 8
       'Soda/Water' // 2.25
@@ -35,18 +35,24 @@ describe('getMealDayTotal', () => {
   );
 
   it('should work', () => {
-    expect(getMealDayTotal(mealList, 1)).toBe(6.3 + 4.5 + 8 + 2.25);
+    expect(getMealDayTotal(mealList, 1)).toBeCloseTo(
+      (6.55 + 4.5 + 8 + 2.25) * 0.9,
+      2
+    );
 
-    expect(getMealDayTotal(mealList, 2)).toBe((6.3 + 4.5 + 8 + 2.25) * 2);
+    expect(getMealDayTotal(mealList, 2)).toBeCloseTo(
+      (6.55 + 4.5 + 8 + 2.25) * 2 * 0.9,
+      1
+    );
   });
 
   it('should work with discount', () => {
     expect(getMealDayTotal(mealList, 1, true)).toBe(
-      6.3 * 0.48 + 4.5 * 0.7 + 8 * 0.7 + 2.25
+      6.55 * 0.48 + 4.5 * 0.7 + 8 * 0.7 + 2.25
     );
 
     expect(getMealDayTotal(mealList, 2, true)).toBe(
-      (6.3 * 0.48 + 4.5 * 0.7 + 8 * 0.7 + 2.25) * 2
+      (6.55 * 0.48 + 4.5 * 0.7 + 8 * 0.7 + 2.25) * 2
     );
   });
 });
@@ -55,7 +61,7 @@ describe('getMealTotal', () => {
   const mealList1: MealReference[] = meals
     .filter((m) =>
       [
-        'Breakfast', // 6.3
+        'Breakfast', // 6.55
         'Grain Bowl' // 8
       ].some((mName) => m.name === mName)
     ) // Lottie and Falcon
@@ -81,22 +87,22 @@ describe('getMealTotal', () => {
   it('should work for 1 day', () => {
     expect(
       getMealTotal(userMeals, [0, 1, 0, 0, 0, 0, 0], false, meals) // mealList1
-    ).toBe(14.3);
+    ).toBeCloseTo((6.55 + 8) * 0.9, 2);
     expect(
       getMealTotal(userMeals, [1, 0, 0, 0, 0, 0, 0], false, meals) // mealList2
-    ).toBe(6.75);
+    ).toBeCloseTo(6.75 * 0.9, 2);
   });
 
   it('should work for multiple days', () => {
-    expect(getMealTotal(userMeals, [1, 1, 0, 0, 0, 0, 0], false, meals)).toBe(
-      21.05
-    );
+    expect(
+      getMealTotal(userMeals, [1, 1, 0, 0, 0, 0, 0], false, meals)
+    ).toBeCloseTo((6.55 + 8 + 6.75) * 0.9, 2);
   });
 
   it('should work for discount', () => {
     expect(
       getMealTotal(userMeals, [0, 1, 0, 0, 0, 0, 0], true, meals)
-    ).toBeCloseTo(3.02 + 5.6);
+    ).toBeCloseTo(6.55 * 0.48 + 5.6);
   });
 });
 
@@ -104,7 +110,7 @@ describe('calculateDateWhenRunOut', () => {
   const mealList1: MealReference[] = meals
     .filter((m) =>
       [
-        'Breakfast', // 6.3
+        'Breakfast', // 6.55
         'Grain Bowl' // 8
       ].some((mName) => m.name === mName)
     ) // Lottie and Falcon
@@ -136,7 +142,7 @@ describe('calculateDateWhenRunOut', () => {
         new Date('06/08/2024'),
         35
       )
-    ).toStrictEqual(new Date('05/07/2024'));
+    ).toStrictEqual(new Date('05/08/2024'));
   });
   it('should return the end date if money never runs out', () => {
     expect(


### PR DESCRIPTION
I've abstracted the switch into its own component and set up the app to apply the a la carte discount instead of not applying one at all if the user does not use DD. This also fixes the suggested starting balance and updates the unit test for calculationEngine.ts to reflect both these changes and the increased Lottie prices. Note that updating that file is not currently straightforward due to the amount of hardcoded values, we should consider some refactoring.