### PR TITLE
Added "what's new" modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import Tutorial from './components/modals/Tutorial';
 import tutorialSteps from './static/tutorialSteps';
 import AvailableMeals from './components/sections/AvailableMeals';
 import Menu from './components/other/Menu';
+import WhatsNewModal from './components/modals/WhatsNewModal';
 
 function App() {
   /**
@@ -271,6 +272,7 @@ function App() {
                       >
                         <Menu />
                         <ScreenContainer>
+                          <WhatsNewModal />
                           <header className='bg-messiah-blue rounded-xl border-4 border-white shadow-md w-full mb-4'>
                             <h1 className='font-semibold text-4xl text-white text-center p-8'>
                               Messiah Meal Planner

--- a/src/components/containers/ModalContainer.tsx
+++ b/src/components/containers/ModalContainer.tsx
@@ -86,52 +86,56 @@ const ModalContainer = ({
   const handleCancel = onCancel || toggleVisible;
 
   return (
-      <div className={`${isVisible ? '' : 'hidden'} h-screen w-screen bg-opacity-50 bg-slate-900 
-        fixed top-0 left-0 flex items-center justify-center z-50`}>
-        {/* The actual modal component */}
-        <div
-          className={`text-center bg-white p-5 m-4 flex flex-col rounded-lg
+    <div
+      className={`${
+        isVisible ? '' : 'hidden'
+      } h-screen w-screen bg-opacity-50 bg-slate-900 
+        fixed top-0 left-0 flex items-center justify-center z-50`}
+    >
+      {/* The actual modal component */}
+      <div
+        className={`text-center bg-white p-5 m-4 flex flex-col rounded-lg
           ${
             minimalSpace
               ? ''
               : 'w-full h-[80%] sm:w-auto sm:h-auto sm:min-w-[500px] sm:min-h-[500px] sm:max-w-[800px] sm:max-h-screen'
           }`}
-        >
-          {
-            /* Title goes here */
-            title !== null && title !== undefined ? (
-              <SectionHeader text={title} />
-            ) : (
-              <></>
-            )
-          }
-          {/* Content goes here */}
-          <div
-            className={`flex-grow flex flex-col 
+      >
+        {
+          /* Title goes here */
+          title !== null && title !== undefined ? (
+            <SectionHeader text={title} />
+          ) : (
+            <></>
+          )
+        }
+        {/* Content goes here */}
+        <div
+          className={`flex-grow flex flex-col 
               ${minimalSpace ? '' : 'overflow-y-scroll'}
               ${
                 centered
                   ? 'justify-center'
                   : 'justify-start align-center text-left'
               } mt-4`}
-          >
-            {children}
-          </div>
-          {/* Confirm and cancel buttons */}
-          <div className='flex-shrink flex flex-row justify-center'>
-            {!onlyCancel ? (
-              <Button
-                title={confirmText}
-                onClick={handleConfirm}
-                disabled={confirmDisabled}
-              />
-            ) : (
-              ''
-            )}
-            <Button title={cancelText} onClick={handleCancel} frame />
-          </div>
+        >
+          {children}
+        </div>
+        {/* Confirm and cancel buttons */}
+        <div className='flex-shrink flex flex-row justify-center'>
+          {!onlyCancel ? (
+            <Button
+              title={confirmText}
+              onClick={handleConfirm}
+              disabled={confirmDisabled}
+            />
+          ) : (
+            ''
+          )}
+          <Button title={cancelText} onClick={handleCancel} frame />
         </div>
       </div>
+    </div>
   );
 };
 

--- a/src/components/modals/WhatsNewModal.tsx
+++ b/src/components/modals/WhatsNewModal.tsx
@@ -1,0 +1,59 @@
+import ModalContainer from '../containers/ModalContainer';
+import usePersistentState from '../../hooks/usePersistentState';
+import { useEffect, useState } from 'react';
+import ReleaseNoteType from '../../types/releaseNoteType';
+import releaseNotes from '../../static/releaseNotes';
+import ReleaseNotes from '../other/ReleaseNotes';
+
+const WhatsNewModal = () => {
+  const [mostRecentVersion, setMostRecentVersion] = usePersistentState<string>(
+    'mostRecentVersion',
+    '0.0.0'
+  );
+
+  const [isNewUser] = usePersistentState('isNewUser', true);
+
+  const [visible, setVisible] = useState(false);
+
+  const [releaseNotesToDisplay, setReleaseNotesToDisplay] = useState<
+    ReleaseNoteType[]
+  >([]);
+
+  const hide = () => {
+    setMostRecentVersion(APP_VERSION);
+    setVisible(false);
+  };
+
+  useEffect(() => {
+    if (mostRecentVersion < APP_VERSION && !isNewUser) {
+      setVisible(true);
+      setReleaseNotesToDisplay(
+        releaseNotes.filter(
+          (note) =>
+            note.versionNumber >= mostRecentVersion &&
+            note.versionNumber <= APP_VERSION
+        )
+      );
+    } else if (isNewUser) {
+      setMostRecentVersion(APP_VERSION);
+    }
+  }, [mostRecentVersion, isNewUser, setMostRecentVersion]);
+
+  return (
+    visible && (
+      <ModalContainer
+        title="What's New?"
+        cancelText='Got it!'
+        onCancel={hide}
+        onlyCancel={true}
+        centered={false}
+      >
+        {releaseNotesToDisplay.map((note) => (
+          <ReleaseNotes {...note} key={note.versionNumber} />
+        ))}
+      </ModalContainer>
+    )
+  );
+};
+
+export default WhatsNewModal;

--- a/src/components/other/ReleaseNotes.tsx
+++ b/src/components/other/ReleaseNotes.tsx
@@ -1,0 +1,36 @@
+import ReleaseNoteType from '../../types/releaseNoteType';
+
+/**
+ * Component for displaying release notes
+ *
+ * @param {ReleaseNotesProps} { versionNumber, bugFixes, enhancements } - Props for the component
+ * @returns {JSX.Element} - The rendered component
+ */
+const ReleaseNotes = ({
+  versionNumber,
+  bugFixes,
+  enhancements
+}: ReleaseNoteType) => (
+  <>
+    <p>
+      <h3 className='text-lg text-bold'>
+        Version {versionNumber} Release Notes:
+      </h3>
+      <h4>Bug Fixes:</h4>
+      <ul className='list-disc list-inside'>
+        {bugFixes.map((bug, i) => (
+          <li key={i}>{bug}</li>
+        ))}
+      </ul>
+      <h4>New Features:</h4>
+      <ul className='list-disc list-inside'>
+        {enhancements.map((enhancement, i) => (
+          <li key={i}>{enhancement}</li>
+        ))}
+      </ul>
+    </p>
+    <br />
+  </>
+);
+
+export default ReleaseNotes;

--- a/src/static/releaseNotes.ts
+++ b/src/static/releaseNotes.ts
@@ -1,0 +1,16 @@
+import ReleaseNoteType from '../types/releaseNoteType';
+
+const releaseNotes: ReleaseNoteType[] = [
+  {
+    versionNumber: '0.0.0',
+    bugFixes: [],
+    enhancements: ['Initial release.']
+  },
+  {
+    versionNumber: '0.0.1',
+    bugFixes: [],
+    enhancements: ['Updated union prices for 2024-25 school year.']
+  }
+];
+
+export default releaseNotes;

--- a/src/types/releaseNoteType.ts
+++ b/src/types/releaseNoteType.ts
@@ -1,0 +1,18 @@
+interface ReleaseNoteType {
+  /**
+   * String representing the version number
+   */
+  versionNumber: string;
+
+  /**
+   * Array of strings representing bug fixes
+   */
+  bugFixes: string[];
+
+  /**
+   * Array of strings representing new features
+   */
+  enhancements: string[];
+}
+
+export default ReleaseNoteType;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+declare const APP_VERSION: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,5 +8,8 @@ export default defineConfig({
   server: {
     host: true,
     port: 5173
+  },
+  define: {
+    APP_VERSION: JSON.stringify(process.env.npm_package_version)
   }
 });


### PR DESCRIPTION
I added a modal that shows to returning users who have not yet used the latest version, it shows the changes for all versions since the last one they used. Note that we will need to do the following for all PRs going forward for this to work:

*For PRs from feature branches into development:*
- Update ```src/static/releaseNotes.ts``` to add the release version if necessary, as well as the changes made.
- This PR includes the notes for the Union prices since that was coded concurrently with this and as such the necessary files do not exist in that branch.

*For PRs from development into master:*
- Update ```package.json``` and advance the version number to match the new version added to the releaseNotes static file.