### PR TITLE
Mmp 134 meal table overflow

### DIFF
--- a/src/components/containers/table/TableCell.tsx
+++ b/src/components/containers/table/TableCell.tsx
@@ -65,7 +65,7 @@ const TableCell = ({
             isCustom || sortState !== SortState.NONE ? 'text-messiah-blue' : ''
           } 
           bg-transparent border-none font-inter underline 
-          hover:text-messiah-blue-hover p-0 m-0 text-nowrap inline-flex transition duration-50`}
+          hover:text-messiah-blue-hover p-0 m-0 text-left inline-flex transition duration-50`}
           type='button'
           onClick={onCustomClick}
         >

--- a/src/components/containers/table/TableCell.tsx
+++ b/src/components/containers/table/TableCell.tsx
@@ -58,7 +58,7 @@ const TableCell = ({
   const importanceStyle = IMPORTANCE_CLASSES[importance] ?? 'font-normal';
 
   return (
-    <td className={`${importanceStyle} p-2 text-center`}>
+    <td className={`${importanceStyle} p-1 py-2 sm:p-2 text-center`}>
       {onCustomClick !== undefined ? (
         <button
           className={`${

--- a/src/static/releaseNotes.ts
+++ b/src/static/releaseNotes.ts
@@ -19,7 +19,7 @@ const releaseNotes: ReleaseNoteType[] = [
     bugFixes: [
       'Fixed an issue where all meals would trigger the error highlighting in the day editor.',
       'Fixed issue where tutorial would cover up the notifications.',
-      'Fixed meal table overflow'
+      'Fixed meal table overflow.'
     ],
     enhancements: []
   }

--- a/src/static/releaseNotes.ts
+++ b/src/static/releaseNotes.ts
@@ -20,7 +20,7 @@ const releaseNotes: ReleaseNoteType[] = [
       'Fixed an issue where all meals would trigger the error highlighting in the day editor.',
       'Fixed issue where tutorial would cover up the notifications.',
       'Fixed meal table overflow.',
-      'Fixed the price of Union Acai bowls',
+      'Fixed the price of Union Acai bowls.',
       'Fixed an issue where all meals would trigger the error highlighting in the day editor.'
     ],
     enhancements: []

--- a/src/static/releaseNotes.ts
+++ b/src/static/releaseNotes.ts
@@ -18,7 +18,8 @@ const releaseNotes: ReleaseNoteType[] = [
     versionNumber: '0.0.2',
     bugFixes: [
       'Fixed an issue where all meals would trigger the error highlighting in the day editor.',
-      'Fixed issue where tutorial would cover up the notifications.'
+      'Fixed issue where tutorial would cover up the notifications.',
+      'Fixed meal table overflow'
     ],
     enhancements: []
   }


### PR DESCRIPTION
I reduced the padding on meal table cells, so the overflow doesn't happen until width <= 360. I don't know what else to do besides reducing padding in the section container or reducing font sizes, though I think this is good enough.