### PR TITLE
MMP-141-fix-switch-component-initial-render

### DIFF
--- a/src/components/other/Highlighter.tsx
+++ b/src/components/other/Highlighter.tsx
@@ -82,7 +82,7 @@ const Highlighter = ({
    * Initial render to set position without transition
    */
   useEffect(() => {
-    updateHighlightPosition();
+    requestAnimationFrame(updateHighlightPosition);
     setRenderNumber(renderNumber < 2 ? renderNumber + 1 : renderNumber); // Disable initial render flag
   }, [renderNumber, updateHighlightPosition]);
 

--- a/src/static/releaseNotes.ts
+++ b/src/static/releaseNotes.ts
@@ -17,6 +17,7 @@ const releaseNotes: ReleaseNoteType[] = [
   {
     versionNumber: '0.0.2',
     bugFixes: [
+      'Fixed initial positioning of switches',
       'Fixed the price of Union Acai bowls',
       'Fixed an issue where all meals would trigger the error highlighting in the day editor.'
     ],


### PR DESCRIPTION
I think I may have fixed Issue #83. I modified the ```useEffect``` call that handles the initial render to wrap the update position function in ```requestAnimationFrame``` which waits until the DOM is loaded. I am not getting any issues now, though sometimes I don't see it even without this change so I can't be sure, let me know if you still have issues.