### PR TITLE
Added handling for legacy meals

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -297,9 +297,9 @@ function App() {
       customMeals={customMeals}
       setCustomMeals={setCustomMeals}
     >
-    <IfFulfilled state={mealsState}>
-      <Menu /> 
-    </IfFulfilled>  
+      <IfFulfilled state={mealsState}>
+        <Menu />
+      </IfFulfilled>
       <ScreenContainer>
         <WhatsNewModal />
         <header className='bg-messiah-blue rounded-xl border-4 border-white shadow-md w-full mb-4 flex flex-row justify-center items-center gap-4'>
@@ -337,6 +337,9 @@ function App() {
                   <DayEditor order={4} />
                   <Results
                     order={5}
+                    dataIsInvalid={Object.values(userSelectedMeals).some(
+                      (meals) => meals.some((meal: Meal) => meal?.legacy)
+                    )}
                     grandTotal={grandTotal}
                     isUnderBalance={isUnderBalance}
                     difference={difference}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import Menu from './components/other/Menu';
 import WhatsNewModal from './components/modals/WhatsNewModal';
 import ContextProvider from './components/other/ContextProvider';
 import dereferenceMeal from './lib/dereferenceMeal';
+import InvalidModal from './components/modals/InvalidModal';
 
 function App() {
   /**
@@ -317,6 +318,7 @@ function App() {
         <Menu />
       </IfFulfilled>
       <ScreenContainer>
+        {isDataInvalid && <InvalidModal />}
         <WhatsNewModal />
         <header className='bg-messiah-blue rounded-xl border-4 border-white shadow-md w-full mb-4 flex flex-row justify-center items-center gap-4'>
           <h1 className='font-semibold text-4xl text-white text-center py-8'>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import AvailableMeals from './components/sections/AvailableMeals';
 import Menu from './components/other/Menu';
 import WhatsNewModal from './components/modals/WhatsNewModal';
 import ContextProvider from './components/other/ContextProvider';
+import dereferenceMeal from './lib/dereferenceMeal';
 
 function App() {
   /**
@@ -120,6 +121,21 @@ function App() {
    */
   const tutorialDivs = useRef<(HTMLElement | null)[]>(
     Array(tutorialSteps.length).fill(null)
+  );
+
+  /**
+   * Keeps track of whether or not legacy meals are in the userSelectedMeals object
+   */
+  const isDataInvalid = useMemo(
+    () =>
+      Object.values(userSelectedMeals).some((userMeals) =>
+        userMeals.some(
+          (meal: MealReference) =>
+            dereferenceMeal(meal, meals ?? [], customMeals ?? [])?.legacy ===
+            true
+        )
+      ),
+    [userSelectedMeals, meals, customMeals]
   );
 
   /**
@@ -337,9 +353,7 @@ function App() {
                   <DayEditor order={4} />
                   <Results
                     order={5}
-                    dataIsInvalid={Object.values(userSelectedMeals).some(
-                      (meals) => meals.some((meal: Meal) => meal?.legacy)
-                    )}
+                    dataIsInvalid={isDataInvalid}
                     grandTotal={grandTotal}
                     isUnderBalance={isUnderBalance}
                     difference={difference}

--- a/src/components/containers/table/TableCell.tsx
+++ b/src/components/containers/table/TableCell.tsx
@@ -33,6 +33,11 @@ interface TableCellProps {
   isCustom?: boolean;
 
   /**
+   * Whether or not the cell contains invalid data
+   */
+  isInvalid?: boolean;
+
+  /**
    * The click event handler for clicking on a custom meal
    */
   onCustomClick?: () => void;
@@ -53,6 +58,7 @@ const TableCell = ({
   importance = newImportanceIndex(3),
   sortState = SortState.NONE,
   isCustom = false,
+  isInvalid = false,
   onCustomClick
 }: TableCellProps): JSX.Element => {
   const importanceStyle = IMPORTANCE_CLASSES[importance] ?? 'font-normal';
@@ -78,7 +84,7 @@ const TableCell = ({
             ''
           )}
         </button>
-      ) : data === 'N/A' ? (
+      ) : data === 'N/A' || isInvalid ? (
         <span className='text-messiah-red'>{data}</span>
       ) : (
         data

--- a/src/components/containers/table/TableRow.tsx
+++ b/src/components/containers/table/TableRow.tsx
@@ -91,17 +91,15 @@ const TableRow = ({
 
   return (
     <>
-      <tr ref={tr}>
+      <tr ref={tr} className={!data.name || data?.legacy ? 'bg-red-100' : ''}>
         <TableCell
-          data={
-            data.location ?? <span className='text-messiah-red'>UNKNOWN</span>
-          }
+          data={data.location ?? 'UNKNOWN'}
+          isInvalid={!data?.location || data?.legacy}
           importance={newImportanceIndex(1)}
         />
         <TableCell
-          data={
-            data.name ?? <span className='text-messiah-red'>INVALID MEAL</span>
-          }
+          data={data.name ?? 'INVALID MEAL'}
+          isInvalid={!data.name || data?.legacy}
           isCustom={data.isCustom}
           importance={newImportanceIndex(2)}
           onCustomClick={
@@ -112,6 +110,7 @@ const TableRow = ({
         />
         <TableCell
           data={isNaN(price) ? 'N/A' : formatCurrency(price)}
+          isInvalid={!data?.price || data?.legacy}
           importance={newImportanceIndex(2)}
         />
         {buttonIcon && buttonOnClick ? (

--- a/src/components/modals/InvalidModal.tsx
+++ b/src/components/modals/InvalidModal.tsx
@@ -1,0 +1,28 @@
+import ModalContainer from '../containers/ModalContainer';
+import { useState } from 'react';
+
+const InvalidModal = () => {
+  const [visible, setVisible] = useState(true);
+
+  const hide = () => {
+    setVisible(false);
+  };
+
+  return (
+    visible && (
+      <ModalContainer
+        title='Invalid Meals'
+        cancelText='Got it!'
+        onCancel={hide}
+        onlyCancel={true}
+        centered={false}
+      >
+        Your meal plan contains meals that no longer exist. Please update your
+        plan to remove those meals in order to continue receiving accurate
+        calculations.
+      </ModalContainer>
+    )
+  );
+};
+
+export default InvalidModal;

--- a/src/components/modals/InvalidModal.tsx
+++ b/src/components/modals/InvalidModal.tsx
@@ -1,12 +1,19 @@
+import Meal from '../../types/Meal';
 import ModalContainer from '../containers/ModalContainer';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
-const InvalidModal = () => {
+const InvalidModal = ({
+  invalidMeals
+}: {
+  invalidMeals: { [key: string]: Meal[] };
+}) => {
   const [visible, setVisible] = useState(true);
 
   const hide = () => {
     setVisible(false);
   };
+
+  useEffect(() => console.log(invalidMeals), [invalidMeals]);
 
   return (
     visible && (
@@ -19,7 +26,19 @@ const InvalidModal = () => {
       >
         Your meal plan contains meals that no longer exist. Please update your
         plan to remove those meals in order to continue receiving accurate
-        calculations.
+        calculations. The offending meals are listed below:
+        <br />
+        <br />
+        <ul>
+          {Object.keys(invalidMeals).map(
+            (key) =>
+              invalidMeals[key]?.length > 0 && (
+                <li key={key}>
+                  {key}: {invalidMeals[key].map((m) => m.name).join(', ')}
+                </li>
+              )
+          )}
+        </ul>
       </ModalContainer>
     )
   );

--- a/src/components/sections/AvailableMeals.tsx
+++ b/src/components/sections/AvailableMeals.tsx
@@ -152,7 +152,10 @@ const AvailableMeals = ({ order }: AvailableMealsProps) => {
       <MealContainer
         title='Available Meals'
         addOrRemove='Add'
-        meals={[...meals.value, ...customMeals.value]}
+        meals={[
+          ...meals.value.filter((meal) => !meal?.legacy),
+          ...customMeals.value
+        ]}
         buttonOnClick={addToQueue}
         buttonOnClickDay={addToDay}
         createNotification={(name) => `Added ${name} to meal queue`}

--- a/src/components/sections/AvailableMeals.tsx
+++ b/src/components/sections/AvailableMeals.tsx
@@ -142,7 +142,7 @@ const AvailableMeals = ({ order }: AvailableMealsProps) => {
       ...userSelectedMeals.value,
       [day]: [
         ...(userSelectedMeals.value[day] ?? []),
-        { ...meal, instanceId: uuid() }
+        { id: meal.id ?? '', instanceId: uuid() }
       ]
     });
   };

--- a/src/components/sections/DayEditor.tsx
+++ b/src/components/sections/DayEditor.tsx
@@ -130,7 +130,7 @@ const DayEditor = ({ order }: DayEditorProps) => {
   const daysWithErrors = useMemo(
     () =>
       Object.values(userSelectedMealsValue).map((day) =>
-        day.some((m) => !isMeal(m))
+        day.some((m) => !isMeal(m) || m?.legacy)
       ),
     [userSelectedMealsValue]
   );

--- a/src/components/sections/Results.tsx
+++ b/src/components/sections/Results.tsx
@@ -20,6 +20,7 @@ import { userMealsToStackedChart } from '../../lib/mealChartFormat';
 import Divider from '../other/Divider';
 import { TooltipItem } from 'chart.js/auto';
 import tooltip from '../../static/tooltip';
+import { MdErrorOutline } from 'react-icons/md';
 
 interface ResultsProps {
   /**
@@ -46,6 +47,11 @@ interface ResultsProps {
    * The order of this component relative to others.
    */
   order: number;
+
+  /**
+   * Whether the data is invalid.
+   */
+  dataIsInvalid: boolean;
 }
 
 /**
@@ -80,7 +86,8 @@ const Results = ({
   difference,
   grandTotal,
   dayWhenRunOut,
-  order
+  order,
+  dataIsInvalid
 }: ResultsProps) => {
   const balance = useContext(BalanceCtx);
   const weeksOff = useContext(WeeksOffCtx);
@@ -264,6 +271,13 @@ const Results = ({
       setRef={(ref) => tutorialRefs.setValue(ref, 'Results')}
       order={order}
     >
+      {dataIsInvalid && (
+        <div className='bg-red-100 rounded-lg p-4 my-2 text-messiah-red w-full flex flex-row gap-2'>
+          <MdErrorOutline size={25} className='text-messiah-red' />
+          Your meal plan contains meals that no longer exist. Please update your
+          plan to remove these meals.
+        </div>
+      )}
       <div className='text-gray-400 mt-4 mb-1'>
         (Charts are based on the total for 1 week)
       </div>


### PR DESCRIPTION
Added handling for legacy meals. Legacy meals now cause the following to happen:
- Legacy meals do not show up in the available meals list
- If the user has a legacy meal *in either their meal queue or any day*, it is highlighted red in all meal tables
- If the user has a legacy meal *in a given day*, that day is highlighted red in the day selector.
- If the user has any legacy meals *added to any days* a warning message will show in the results section.