### PR TITLE
Fix tutorial buttons opening wrong step when meal queue is off

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "messiah-dining-calculator",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -408,9 +408,9 @@ function App() {
                   <>
                     <AvailableMeals order={2} />
                     {showMealQueue ? <MealQueue order={3} /> : <></>}
-                    <DayEditor order={4} />
+                    <DayEditor order={showMealQueue ? 4 : 3} />
                     <Results
-                      order={5}
+                      order={showMealQueue ? 5 : 4}
                       dataIsInvalid={hasInvalidMeals}
                       grandTotal={grandTotal}
                       isUnderBalance={isUnderBalance}
@@ -418,7 +418,7 @@ function App() {
                       dayWhenRunOut={dayWhenRunOut}
                     />
                     <ResultsBar
-                      order={6}
+                      order={showMealQueue ? 6 : 5}
                       grandTotal={grandTotal}
                       isUnderBalance={isUnderBalance}
                       difference={difference}

--- a/src/static/releaseNotes.ts
+++ b/src/static/releaseNotes.ts
@@ -31,6 +31,11 @@ const releaseNotes: ReleaseNoteType[] = [
       'Ability to toggle the meal queue on and off.',
       'Default values in the meal plan info section make setup a breeze!'
     ]
+  },
+  {
+    versionNumber: '1.0.1',
+    bugFixes: ['Fixed tutorial help buttons when the meal queue is off.'],
+    enhancements: []
   }
 ];
 


### PR DESCRIPTION
I realized that in the production deployment, when I click the tutorial button on the day editor or results, the wrong tutorial modal pops up when the meal queue is off. This is due to our static assigning of the order. This PR fixes that. Just a straight merge to master since it's a real simple fix and we don't have anything else queued up at the moment.